### PR TITLE
[FE] Badge 컴포넌트 구현

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -2,10 +2,10 @@ import router from 'routes/router';
 import { RouterProvider } from 'react-router-dom';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from 'styled-components';
+import { theme } from 'styles/designSystem';
 import { Reset } from 'styled-reset';
 import { RecoilRoot } from 'recoil';
-import { theme } from 'styles/designSystem';
-import { ThemeProvider } from 'styled-components';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -21,12 +21,12 @@ function App() {
     <>
       <QueryClientProvider client={queryClient}>
         <ReactQueryDevtools initialIsOpen={false} />
-        <RecoilRoot>
-          <Reset />
-          <ThemeProvider theme={theme}>
+        <ThemeProvider theme={theme}>
+          <RecoilRoot>
+            <Reset />
             <RouterProvider router={router} />
-          </ThemeProvider>
-        </RecoilRoot>
+          </RecoilRoot>
+        </ThemeProvider>
       </QueryClientProvider>
     </>
   );

--- a/fe/src/components/Badge.tsx
+++ b/fe/src/components/Badge.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { styled } from 'styled-components';
+
+type Props = {
+  variant: 'store' | 'taste';
+  id: number;
+  name: string;
+  onClick?: (id: number, name: string) => void;
+};
+
+export const Badge: React.FC<Props> = ({ variant, id, name, onClick }) => {
+  const BadgeComponent = BADGE_VARIANT[variant];
+  const [active, setActive] = useState(false);
+  const isActive = onClick ? active : false;
+
+  const handleClick = () => {
+    if (onClick) {
+      setActive(!active);
+      onClick(id, name);
+    }
+  };
+
+  return (
+    <BadgeComponent $isActive={isActive} onClick={handleClick}>
+      {name}
+    </BadgeComponent>
+  );
+};
+
+const BaseBadge = styled.div<{ $isActive: boolean }>`
+  font: ${({ theme: { fonts } }) => fonts.displayM12};
+  width: fit-content;
+  padding: 4px 12px;
+  border: 1px solid;
+  text-align: center;
+`;
+
+const TasteMoodBadge = styled(BaseBadge)`
+  color: ${({ theme: { colors } }) => colors.yellow500};
+  background-color: ${({ $isActive, theme: { colors } }) =>
+    $isActive ? colors.yellow100 : colors.white};
+  border-color: ${({ theme: { colors } }) => colors.yellow500};
+  border-radius: ${({ theme: { radius } }) => radius.large};
+  padding: 4px 12px;
+`;
+
+const StoreMoodBadge = styled(BaseBadge)`
+  color: ${({ $isActive, theme: { colors } }) =>
+    $isActive ? colors.blue100 : colors.blue500};
+  background-color: ${({ $isActive, theme: { colors } }) =>
+    $isActive ? colors.blue500 : colors.blue100};
+  border-color: ${({ $isActive, theme: { colors } }) =>
+    $isActive ? colors.blue500 : colors.blue100};
+  border-radius: ${({ theme: { radius } }) => radius.small};
+  padding: 3px 12px;
+`;
+
+const BADGE_VARIANT = {
+  taste: TasteMoodBadge,
+  store: StoreMoodBadge,
+};


### PR DESCRIPTION
## Key changes🔧

## To reviewer👋

- 배지의 종류는 2종류 : `'store'`, `'taste'`
- onClick 속성이 있는 경우에만 활성화, 비활성화 가능
- 없는 경우에는 기본 비활성화 모드. 
  - 그래서 피그마에 있는 닉넴 옆에 붙는 뱃지의 경우 디자인과 다르게 일단 배경색이 들어가지 않음

![image](https://github.com/foody-moody/foodymoody/assets/95265031/e018808f-aedd-42c1-a46d-8cf906686378)


```javascript
// 클릭할 필요가 없는 뱃지
        <Badge
          variant="store"
          key={badge.id}
          id={badge.id}
          name={badge.name}
        />
```

```javascript
// 클릭으로 선택 가능한 뱃지의 경우
        <Badge
          variant="store"
          key={badge.id}
          id={badge.id}
          name={badge.name}
          onClick={handleBadgeClick}
        />
```

