### PR TITLE
[FE] Dropdown 컴포넌트 구현

### DIFF
--- a/fe/src/components/common/dropdown/Dropdown.tsx
+++ b/fe/src/components/common/dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import { styled } from 'styled-components';
-import { useDetectClose } from 'hooks/useDetectClose';
+import { useDropdown } from 'hooks/useDropdown';
 
 type Props = {
   opener: React.ReactNode;
@@ -13,7 +13,7 @@ export const Dropdown: React.FC<Props> = (
 ) => {
   const dropdownRef = useRef<HTMLUListElement>(null);
   const openerRef = useRef<HTMLDivElement>(null);
-  const { isOpen, handleToggleDropdown } = useDetectClose({
+  const { isOpen, handleToggleDropdown } = useDropdown({
     dropdownRef,
     openerRef,
   });

--- a/fe/src/components/common/dropdown/Dropdown.tsx
+++ b/fe/src/components/common/dropdown/Dropdown.tsx
@@ -1,0 +1,78 @@
+import React, { useRef } from 'react';
+import { styled } from 'styled-components';
+import { useDetectClose } from 'hooks/useDetectClose';
+
+type Props = {
+  opener: React.ReactNode;
+  align?: 'left' | 'right';
+  children: React.ReactNode;
+};
+
+export const Dropdown: React.FC<Props> = (
+  { opener, align = 'left', children }
+) => {
+  const dropdownRef = useRef<HTMLUListElement>(null);
+  const openerRef = useRef<HTMLDivElement>(null);
+  const { isOpen, setIsOpen } = useDetectClose({
+    dropdownRef,
+    openerRef,
+  });
+
+  const handleToggleDropdown = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <Wrapper>
+      <Opener onClick={handleToggleDropdown} ref={openerRef}>
+        {opener}
+      </Opener>
+      {isOpen && (
+        <DropdownBox
+          ref={dropdownRef}
+          $align={align}
+          onClick={handleToggleDropdown}
+        >
+          {children}
+        </DropdownBox>
+      )}
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  width: fit-content;
+  position: relative;
+`;
+
+const DropdownBox = styled.ul<{ $align: 'left' | 'right' }>`
+  display: flex;
+  flex-direction: column;
+  width: 270px;
+  position: absolute;
+  top: 100%;
+  ${({ $align }) => $align}: 0;
+
+  border-radius: 0px 0px 40px 0px;
+  border: 1px solid ${({ theme }) => theme.colors.black};
+  overflow: hidden;
+`;
+
+const Opener = styled.div`
+  display: flex;
+
+  width: fit-content;
+  height: fit-content;
+  align-items: center;
+
+  cursor: pointer;
+  border-radius: ${({ theme }) => theme.radius.small};
+
+  &:hover {
+    background: ${({ theme: { colors } }) => colors.bgGray200};
+  }
+`;

--- a/fe/src/components/common/dropdown/Dropdown.tsx
+++ b/fe/src/components/common/dropdown/Dropdown.tsx
@@ -13,18 +13,10 @@ export const Dropdown: React.FC<Props> = (
 ) => {
   const dropdownRef = useRef<HTMLUListElement>(null);
   const openerRef = useRef<HTMLDivElement>(null);
-  const { isOpen, setIsOpen } = useDetectClose({
+  const { isOpen, handleToggleDropdown } = useDetectClose({
     dropdownRef,
     openerRef,
   });
-
-  const handleToggleDropdown = () => {
-    setIsOpen(!isOpen);
-  };
-
-  const handleClose = () => {
-    setIsOpen(false);
-  };
 
   return (
     <Wrapper>
@@ -56,6 +48,7 @@ const DropdownBox = styled.ul<{ $align: 'left' | 'right' }>`
   position: absolute;
   top: 100%;
   ${({ $align }) => $align}: 0;
+  background-color: ${({ theme }) => theme.colors.white};
 
   border-radius: 0px 0px 40px 0px;
   border: 1px solid ${({ theme }) => theme.colors.black};

--- a/fe/src/components/common/dropdown/Dropdown.tsx
+++ b/fe/src/components/common/dropdown/Dropdown.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import { styled } from 'styled-components';
+import { useAnimation } from 'hooks/useAnimation';
 import { useDropdown } from 'hooks/useDropdown';
 
 type Props = {
@@ -18,16 +19,21 @@ export const Dropdown: React.FC<Props> = (
     openerRef,
   });
 
+  const { shouldRender, handleTransitionEnd, animationTrigger } =
+    useAnimation(isOpen);
+
   return (
     <Wrapper>
       <Opener onClick={handleToggleDropdown} ref={openerRef}>
         {opener}
       </Opener>
-      {isOpen && (
+      {shouldRender && (
         <DropdownBox
           ref={dropdownRef}
           $align={align}
+          $animationTrigger={animationTrigger}
           onClick={handleToggleDropdown}
+          onTransitionEnd={handleTransitionEnd}
         >
           {children}
         </DropdownBox>
@@ -41,7 +47,10 @@ const Wrapper = styled.div`
   position: relative;
 `;
 
-const DropdownBox = styled.ul<{ $align: 'left' | 'right' }>`
+const DropdownBox = styled.ul<{
+  $align: 'left' | 'right';
+  $animationTrigger: boolean;
+}>`
   display: flex;
   flex-direction: column;
   width: 270px;
@@ -49,7 +58,10 @@ const DropdownBox = styled.ul<{ $align: 'left' | 'right' }>`
   top: 100%;
   ${({ $align }) => $align}: 0;
   background-color: ${({ theme }) => theme.colors.white};
+  transform: ${({ $animationTrigger }) =>
+    $animationTrigger ? 'translateY(0);' : 'translateY(-10px);'};
 
+  transition: 0.2s ease;
   border-radius: 0px 0px 40px 0px;
   border: 1px solid ${({ theme }) => theme.colors.black};
   overflow: hidden;
@@ -63,9 +75,9 @@ const Opener = styled.div`
   align-items: center;
 
   cursor: pointer;
-  border-radius: ${({ theme }) => theme.radius.small};
+  border-radius: 4px;
 
   &:hover {
-    background: ${({ theme: { colors } }) => colors.bgGray200};
+    background: ${({ theme: { colors } }) => colors.bgGray50};
   }
 `;

--- a/fe/src/components/common/dropdown/Dropdown.tsx
+++ b/fe/src/components/common/dropdown/Dropdown.tsx
@@ -55,25 +55,22 @@ const DropdownBox = styled.ul<{
   flex-direction: column;
   width: 270px;
   position: absolute;
-  top: 100%;
+  top: 102%;
   ${({ $align }) => $align}: 0;
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${({ theme: { colors } }) => colors.white};
   transform: ${({ $animationTrigger }) =>
-    $animationTrigger ? 'translateY(0);' : 'translateY(-10px);'};
-
-  transition: 0.2s ease;
+    $animationTrigger ? 'translateY(0);' : 'translateY(-5px);'};
+  transition: 0.3s ease-in-out;
   border-radius: 0px 0px 40px 0px;
-  border: 1px solid ${({ theme }) => theme.colors.black};
+  border: 1px solid ${({ theme: { colors } }) => colors.black};
   overflow: hidden;
 `;
 
 const Opener = styled.div`
   display: flex;
-
+  align-items: center;
   width: fit-content;
   height: fit-content;
-  align-items: center;
-
   cursor: pointer;
   border-radius: 4px;
 

--- a/fe/src/components/common/dropdown/DropdownRow.tsx
+++ b/fe/src/components/common/dropdown/DropdownRow.tsx
@@ -6,7 +6,6 @@ type Props = {
 };
 
 export const DropdownRow: React.FC<Props> = ({  children, onClick }) => {
-
   const handleClick = () => {
     onClick?.();
   }

--- a/fe/src/components/common/dropdown/DropdownRow.tsx
+++ b/fe/src/components/common/dropdown/DropdownRow.tsx
@@ -1,0 +1,25 @@
+import { styled } from 'styled-components';
+
+type Props = {
+  children: React.ReactNode;
+  onClick?(): void;
+};
+
+export const DropdownRow: React.FC<Props> = ({  children, onClick }) => {
+
+  const handleClick = () => {
+    onClick?.();
+  }
+
+  return <Wrapper onClick={handleClick}>{children}</Wrapper>;
+};
+
+const Wrapper = styled.li`
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  padding: 16px;
+
+  &:hover {
+    background: ${({ theme: { colors } }) => colors.bgGray200};
+  }
+`;

--- a/fe/src/hooks/useAnimation.ts
+++ b/fe/src/hooks/useAnimation.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+type UseAnimationReturn = {
+  shouldRender: boolean;
+  handleTransitionEnd: () => void;
+  animationTrigger: boolean;
+};
+export const useAnimation = (condition: boolean): UseAnimationReturn => {
+  const [isComplete, setComplete] = useState(false);
+
+  useEffect(() => {
+    if (condition) {
+      setComplete(true);
+    }
+  }, [condition]);
+
+  const shouldRender = condition || isComplete;
+
+  const animationTrigger = condition && isComplete;
+
+  const handleTransitionEnd = () => {
+    if (!condition) setComplete(false);
+  };
+
+  return { shouldRender, handleTransitionEnd, animationTrigger };
+};

--- a/fe/src/hooks/useAnimation.ts
+++ b/fe/src/hooks/useAnimation.ts
@@ -5,6 +5,7 @@ type UseAnimationReturn = {
   handleTransitionEnd: () => void;
   animationTrigger: boolean;
 };
+
 export const useAnimation = (condition: boolean): UseAnimationReturn => {
   const [isComplete, setComplete] = useState(false);
 

--- a/fe/src/hooks/useDetectClose.ts
+++ b/fe/src/hooks/useDetectClose.ts
@@ -21,7 +21,7 @@ export const useDetectClose = ({ dropdownRef, openerRef, initialValue = false }:
       }
 
       if (dropdownRef?.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
+        setIsOpen(!isOpen)
       }
     };
 

--- a/fe/src/hooks/useDetectClose.ts
+++ b/fe/src/hooks/useDetectClose.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+
+type PropsType = {
+  dropdownRef?: React.RefObject<HTMLElement>;
+  openerRef?: React.RefObject<HTMLElement>;
+  initialValue?: boolean;
+};
+
+export const useDetectClose = ({ dropdownRef, openerRef, initialValue = false }: PropsType = {} ) => {
+
+  const [isOpen, setIsOpen] = useState(initialValue);
+
+  const handleToggleDropdown = () => {
+    setIsOpen(!isOpen);
+  };
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (openerRef?.current && openerRef.current.contains(event.target as Node)) {
+        return;
+      }
+
+      if (dropdownRef?.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('click', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [isOpen, openerRef, dropdownRef]);
+
+  return { isOpen, handleToggleDropdown};
+};

--- a/fe/src/hooks/useDropdown.ts
+++ b/fe/src/hooks/useDropdown.ts
@@ -6,7 +6,7 @@ type PropsType = {
   initialValue?: boolean;
 };
 
-export const useDetectClose = ({ dropdownRef, openerRef, initialValue = false }: PropsType = {} ) => {
+export const useDropdown = ({ dropdownRef, openerRef, initialValue = false }: PropsType = {} ) => {
 
   const [isOpen, setIsOpen] = useState(initialValue);
 
@@ -16,11 +16,14 @@ export const useDetectClose = ({ dropdownRef, openerRef, initialValue = false }:
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-      if (openerRef?.current && openerRef.current.contains(event.target as Node)) {
+
+      const target = event.target as Node;
+
+      if (openerRef?.current && openerRef.current.contains(target)) {
         return;
       }
 
-      if (dropdownRef?.current && !dropdownRef.current.contains(event.target as Node)) {
+      if (dropdownRef?.current && !dropdownRef.current.contains(target)) {
         setIsOpen(!isOpen)
       }
     };

--- a/fe/src/hooks/useDropdown.ts
+++ b/fe/src/hooks/useDropdown.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect } from 'react';
 
 type PropsType = {
-  dropdownRef?: React.RefObject<HTMLElement>;
-  openerRef?: React.RefObject<HTMLElement>;
+  dropdownRef: React.RefObject<HTMLElement>;
+  openerRef: React.RefObject<HTMLElement>;
   initialValue?: boolean;
 };
 
-export const useDropdown = ({ dropdownRef, openerRef, initialValue = false }: PropsType = {} ) => {
+export const useDropdown = ({ dropdownRef, openerRef, initialValue = false }: PropsType ) => {
 
   const [isOpen, setIsOpen] = useState(initialValue);
 
@@ -19,11 +19,11 @@ export const useDropdown = ({ dropdownRef, openerRef, initialValue = false }: Pr
 
       const target = event.target as Node;
 
-      if (openerRef?.current && openerRef.current.contains(target)) {
+      if (openerRef.current?.contains(target)) {
         return;
       }
 
-      if (dropdownRef?.current && !dropdownRef.current.contains(target)) {
+      if (!dropdownRef.current?.contains(target)) {
         setIsOpen(!isOpen)
       }
     };

--- a/fe/src/hooks/useDropdown.ts
+++ b/fe/src/hooks/useDropdown.ts
@@ -7,7 +7,6 @@ type PropsType = {
 };
 
 export const useDropdown = ({ dropdownRef, openerRef, initialValue = false }: PropsType ) => {
-
   const [isOpen, setIsOpen] = useState(initialValue);
 
   const handleToggleDropdown = () => {
@@ -16,7 +15,6 @@ export const useDropdown = ({ dropdownRef, openerRef, initialValue = false }: Pr
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
-
       const target = event.target as Node;
 
       if (openerRef.current?.contains(target)) {


### PR DESCRIPTION
## Key changes🔧
- 
## To reviewer👋
- animation훅 추가
  - [FE노션에 설명 기록](https://www.notion.so/useAnimation-e21c541ea3b442ccbf14c08130a5a77e?pvs=4)
  - 애니메이션이 좀 안어울리는 것 같기도 해서 쫌따 같이 봐보져🤔
- dropdown훅 추가
  - opener, dropdown ref를 인자로 받습니다 
  - isOpen일때 이벤트리스너를 달고 handleClickOutside를 실행

- dropdown: DropdownRow 컴포넌트가 children으로 들어갑니다
```
 <Dropdown opener={<DotGhostIcon />}>
    {Array.from({ length: 5 }).map((_, i) => (
      <DropdownRow key={i}>{i}</DropdownRow>
    ))}
  </Dropdown>
```
