### PR TITLE
[FE] 이미지 업로드(피드수정, 프로필 사진 수정)

### DIFF
--- a/fe/src/components/commentInput/CommentInput.tsx
+++ b/fe/src/components/commentInput/CommentInput.tsx
@@ -13,7 +13,7 @@ type Props = {
   onSubmitComment?(): void;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-export const CommentInputContainer: React.FC<Props> = ({
+export const CommentInput: React.FC<Props> = ({
   value,
   limitedLength,
   onChangeValue,

--- a/fe/src/components/common/carousel/Carousel.tsx
+++ b/fe/src/components/common/carousel/Carousel.tsx
@@ -24,7 +24,7 @@ export const Carousel: React.FC<Props> = ({ images }) => {
       <CustomCarousel {...settings}>
         {images.map((image) => (
           <Slide key={image.id}>
-            <Image src={image.imageUrl} /> {/* alt 추가하기. */}
+            <Image src={image.image.url} /> {/* alt 추가하기. */}
             <MenuRateTag
               menu={{ name: image.menu.name, rating: image.menu.rating }}
             />

--- a/fe/src/components/common/commentItem/CommentBox.tsx
+++ b/fe/src/components/common/commentItem/CommentBox.tsx
@@ -1,7 +1,7 @@
 import { useState, forwardRef } from 'react';
 import { useGetReplies, usePostReply } from 'service/queries/reply';
 import { styled } from 'styled-components';
-import { CommentInputContainer } from 'components/commentInput/CommentInputContainer';
+import { CommentInput } from 'components/commentInput/CommentInput';
 import { TextButton } from 'components/common/button/TextButton';
 import { useAuthState } from 'hooks/auth/useAuth';
 import { useInput } from 'hooks/useInput';
@@ -79,7 +79,7 @@ export const CommentBox = forwardRef<HTMLLIElement, Props>(
         </ReplyButtonBox>
         {isReplying && (
           <ReplyInputBox>
-            <CommentInputContainer
+            <CommentInput
               value={value}
               limitedLength={200}
               onChangeValue={handleChange}

--- a/fe/src/components/common/commentItem/ReplyItem.tsx
+++ b/fe/src/components/common/commentItem/ReplyItem.tsx
@@ -6,6 +6,7 @@ import { useAuthState } from 'hooks/auth/useAuth';
 import { useInput } from 'hooks/useInput';
 import { usePageNavigator } from 'hooks/usePageNavigator';
 import { formatTimeStamp } from 'utils/formatTimeStamp';
+import { generateDefaultUserImage } from 'utils/generateDefaultUserImage';
 import { DotGhostIcon, HeartSmallEmpty, HeartSmallFill } from '../icon/icons';
 import { Input } from '../input/Input';
 import { InputField } from '../input/InputField';
@@ -104,7 +105,11 @@ export const ReplyItem: React.FC<Props> = ({ commentId, reply, createdAt }) => {
     <Wrapper>
       <ReplyRow>
         <ContentLeft>
-          <UserImage imageUrl={reply.member.imageUrl} />
+          <UserImage
+            imageUrl={
+              reply.member.imageUrl || generateDefaultUserImage(reply.member.id)
+            }
+          />
           <FlexColumnBox>
             <ContentHeader>
               <Nickname>{reply.member.nickname}</Nickname>

--- a/fe/src/components/common/feedAction/FeedAction.tsx
+++ b/fe/src/components/common/feedAction/FeedAction.tsx
@@ -16,7 +16,7 @@ type Props = {
 
 export const FeedAction: React.FC<Props> = ({
   feedId,
-  isLiked = false,
+  isLiked,
   likeCount = 0,
   commentCount = 0,
   onClickCommentIcon,
@@ -24,20 +24,14 @@ export const FeedAction: React.FC<Props> = ({
   const { id: param } = useParams() as { id: string };
   const { navigateToLogin } = usePageNavigator();
   const { isLogin } = useAuthState();
-  // const [isLiked, setIsLiked] = useState(false);
   const { mutate: likeMutate } = usePostFeedLike(param);
   const { mutate: unLikeMutate } = useDeleteFeedLike(param);
-  // TODO 로그인유무로 교체 const isLiked = isLogin ? feed.isLiked : false;
-  // feed: query로 받아온 feed데이터
+
   const LikeIcon = isLiked ? HeartFillIcon : HeartBgIcon;
-  const likeFn = isLiked ? unLikeMutate : likeMutate;
 
   const handleSubmitLike = () => {
-    // setIsLiked(!isLiked); // TODO 좋아요 연결시 삭제
-
     if (isLogin) {
-      // likeMutate(feedId);
-      likeFn(feedId);
+      isLiked ? unLikeMutate(feedId) : likeMutate(feedId);
     } else {
       navigateToLogin();
     }

--- a/fe/src/components/common/feedUserInfo/FeedUserInfo.tsx
+++ b/fe/src/components/common/feedUserInfo/FeedUserInfo.tsx
@@ -4,6 +4,7 @@ import { styled } from 'styled-components';
 import { useAuthState } from 'hooks/auth/useAuth';
 import { usePageNavigator } from 'hooks/usePageNavigator';
 import { formatTimeStamp } from 'utils/formatTimeStamp';
+import { generateDefaultUserImage } from 'utils/generateDefaultUserImage';
 import { Badge } from '../badge/Badge';
 import { Dropdown } from '../dropdown/Dropdown';
 import { DropdownRow } from '../dropdown/DropdownRow';
@@ -84,7 +85,10 @@ export const FeedUserInfo: React.FC<Props> = ({
   return (
     <Wrapper>
       <ContentLeft>
-        <UserImage imageUrl={member.imageUrl} onClick={navigateToProfile} />
+        <UserImage
+          imageUrl={member.imageUrl || generateDefaultUserImage(member.id)}
+          onClick={navigateToProfile}
+        />
         <FlexColumnBox>
           <ContentHeader>
             <p>{member.nickname}</p>

--- a/fe/src/components/common/menuItemEditor/ImageBox.tsx
+++ b/fe/src/components/common/menuItemEditor/ImageBox.tsx
@@ -1,19 +1,78 @@
+import React, { useRef, useState } from 'react';
+import { useToast } from 'recoil/toast/useToast';
+import { usePostImage } from 'service/queries/imageUpload';
 import { styled } from 'styled-components';
 import { PlusGhostIcon } from '../icon/icons';
 
 type Props = {
-  imageUrl: string;
-  onClick(): void;
+  menuId: string;
+  imageUrl?: string;
+  onEditMenuImage(id: string, image: ImageType): void;
 };
 
-export const ImageBox: React.FC<Props> = ({ imageUrl, onClick }) => {
-  imageUrl = 'https://picsum.photos/200';
-  // const githubRandomProfileUrl = 'https://picsum.photos/200';
+export const ImageBox: React.FC<Props> = ({
+  menuId,
+  imageUrl,
+  onEditMenuImage,
+}) => {
+  const toast = useToast();
+  const { mutate: imageMutate } = usePostImage('feed');
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const [imageData, setImageData] = useState({
+    id: '',
+    url: imageUrl,
+  });
+
+  const handleImageClick = () => {
+    if (inputRef.current) {
+      inputRef.current.click();
+    }
+  };
+
+  const handleUploadImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    const ALLOWED_TYPES = ['image/png', 'image/jpg', 'image/jpeg'];
+    const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 2; // 2MB
+
+    if (!ALLOWED_TYPES.includes(file.type) || file.size > MAX_FILE_SIZE_BYTES) {
+      toast.noti(
+        '이미지는 2MB 이하의 png, jpg, jpeg 파일만 업로드 가능합니다.'
+      );
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    imageMutate(formData, {
+      onSuccess: (res) => {
+        console.log(res, ' now res');
+        setImageData(res);
+        onEditMenuImage(menuId, res);
+      },
+    });
+
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  };
 
   return (
-    <ImageWrapper onClick={onClick}>
-      {/* <img src={githubRandomProfileUrl} alt="menu item image" /> */}
-      <img src={imageUrl} alt="menu item image" />
+    <ImageWrapper onClick={handleImageClick}>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".png, .jpg, .jpeg"
+        onChange={handleUploadImage}
+      />
+      <img src={imageData.url} alt="menu item image" />
       <PlusGhostIcon />
     </ImageWrapper>
   );
@@ -27,6 +86,7 @@ const ImageWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  cursor: pointer;
 
   &::after {
     content: '';
@@ -38,6 +98,15 @@ const ImageWrapper = styled.div`
     background-color: rgba(0, 0, 0, 0.3);
     pointer-events: none;
     cursor: pointer;
+  }
+
+  input {
+    display: none;
+    /* position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    border: 2px solid red; */
   }
 
   img {

--- a/fe/src/components/common/menuItemEditor/MenuItemEditor.tsx
+++ b/fe/src/components/common/menuItemEditor/MenuItemEditor.tsx
@@ -8,7 +8,7 @@ import { ImageBox } from './ImageBox';
 
 type Props = {
   menuItem: FeedImage; //feedimage로 바꿔야하는지 확인
-  onEditMenuImage: (id: string, imageId: string) => void;
+  onEditMenuImage: (id: string, image: ImageType) => void;
   onEditMenuName: (id: string, name: string) => void;
   onEditStarRating: (id: string, rate: number) => void;
   onRemove: (id: string) => void;
@@ -23,8 +23,7 @@ export const MenuItemEditor: React.FC<Props> = ({
 }) => {
   const {
     id,
-    imageId,
-    imageUrl,
+    image,
     menu: { name, rating },
   } = menuItem;
 
@@ -33,15 +32,16 @@ export const MenuItemEditor: React.FC<Props> = ({
     validator: (value: string) => value.trim().length > 0,
     helperText: '메뉴 이름을 입력해주세요',
   });
-  console.log('imageUrl', imageUrl);
-  console.log('imageId', imageId);
+
+  console.log('imageUrl', image.url);
+  console.log('imageId', image.id);
 
   return (
     <Wrapper>
       <LeftContent>
         <ImageBox
           menuId={id}
-          imageUrl={imageUrl}
+          imageUrl={image.url}
           onEditMenuImage={onEditMenuImage}
         />
         <ContentBody>

--- a/fe/src/components/common/userImage/UserImage.tsx
+++ b/fe/src/components/common/userImage/UserImage.tsx
@@ -2,28 +2,30 @@ import { styled } from 'styled-components';
 
 type UserImageProps = {
   variant?: 'default' | 'edit';
-  imageUrl?: string;
+  imageUrl: string;
   onClick?(): void;
 };
 
-export const UserImage: React.FC<UserImageProps> = (
-  { variant = 'default', imageUrl, onClick }
-) => {
-  const generateDefaultImage = `https://source.boringavatars.com/beam/${imageUrl}`;
-  // TODO imageUrl부분 전역으로 둔 member 아이디로 변경
-  const onErrorImage = (
-    event: React.SyntheticEvent<HTMLImageElement, Event>
-  ) => {
-    event.currentTarget.src = generateDefaultImage;
-  };
+export const UserImage: React.FC<UserImageProps> = ({
+  variant = 'default',
+  imageUrl,
+  onClick,
+}) => {
+  //이미지 경로는 유효함, 그러나 그 이미지 경로가 요청이 안되는 것일때는?
+
+  // const onErrorImage = (
+  //   event: React.SyntheticEvent<HTMLImageElement, Event>
+  // ) => {
+  //   return (event.currentTarget.src = imageUrl); // 에러이미지로 변경
+  // };
 
   return (
     <Img
       onClick={onClick}
       $variant={variant}
-      src={imageUrl || generateDefaultImage}
+      src={imageUrl}
       alt="유저이미지"
-      onError={onErrorImage}
+      // onError={onErrorImage}
     />
   );
 };

--- a/fe/src/components/common/userImage/UserImageEdit.tsx
+++ b/fe/src/components/common/userImage/UserImageEdit.tsx
@@ -1,26 +1,93 @@
+import React, { useRef, useState } from 'react';
+import { useToast } from 'recoil/toast/useToast';
+import { usePostImage } from 'service/queries/imageUpload';
+import { useEditProfileImage } from 'service/queries/profile';
 import { styled } from 'styled-components';
 import { media } from 'styles/mediaQuery';
+import { useAuthState } from 'hooks/auth/useAuth';
+import { generateDefaultUserImage } from 'utils/generateDefaultUserImage';
 import { EditIcon } from '../icon/icons';
 import { UserImage } from './UserImage';
 
-type UserImageEditProps = {
+type Props = {
+  member: ProfileMemberInfo;
+  isAuthor: boolean;
+  imageId?: string;
   imageUrl?: string;
 };
 
-export const UserImageEdit: React.FC<UserImageEditProps> = ({ imageUrl }) => {
-  const randomGithubImageUrl =
-    'https://avatars.githubusercontent.com/u/63034672?v=4';
-  const userImage = imageUrl || randomGithubImageUrl;
+export const UserImageEdit: React.FC<Props> = ({
+  member,
+  isAuthor,
+  imageId,
+  imageUrl,
+}) => {
+  const [imageData, setImageData] = useState({
+    id: imageId,
+    url: imageUrl,
+  });
+  const { userInfo } = useAuthState();
+  const { mutate: imageMutate } = usePostImage('user');
+  const { mutate: profileMutate } = useEditProfileImage(member.id);
 
-  const handleEditImage = () => {};
+  const toast = useToast();
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const isAuthor = false;
+  const defaultImage = generateDefaultUserImage(userInfo.id);
+  const userImage = imageData.url || defaultImage;
+
+  const handleImageClick = () => {
+    if (inputRef.current) {
+      inputRef.current.click();
+    }
+  };
+
+  const handleUploadImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    const ALLOWED_TYPES = ['image/png', 'image/jpg', 'image/jpeg'];
+    const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 2; // 2MB
+
+    if (!ALLOWED_TYPES.includes(file.type) || file.size > MAX_FILE_SIZE_BYTES) {
+      toast.noti(
+        '이미지는 2MB 이하의 png, jpg, jpeg 파일만 업로드 가능합니다.'
+      );
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    imageMutate(formData, {
+      onSuccess: (res) => {
+        console.log(res, ' now res');
+        setImageData(res);
+        //여기에 프로필 수정 mutate하기
+        profileMutate({ profileImageId: res.id, tasteMoodId: null });
+      },
+    });
+
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  };
+  // 프로필 전체 수정 mutate가져와서 바뀐 이미지로 제출할수있게 하기
 
   return (
-    <Wrapper>
+    <Wrapper onClick={handleImageClick}>
       <UserImage variant="edit" imageUrl={userImage} />
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".png, .jpg, .jpeg"
+        onChange={handleUploadImage}
+      />
       {isAuthor && (
-        <EditBtn onClick={handleEditImage}>
+        <EditBtn>
           <EditIcon />
         </EditBtn>
       )}
@@ -30,15 +97,28 @@ export const UserImageEdit: React.FC<UserImageEditProps> = ({ imageUrl }) => {
 
 const Wrapper = styled.div`
   position: relative;
+  cursor: pointer;
+  input {
+    display: none;
+  }
+
   img {
     width: 100px;
     height: 100px;
+    min-width: 100px;
+    max-width: 100px;
+    min-height: 100px;
+    max-height: 100px;
   }
 
   ${media.md} {
     img {
       width: 75px;
       height: 75px;
+      min-width: 75px;
+      max-width: 75px;
+      min-height: 75px;
+      max-height: 75px;
     }
   }
 `;

--- a/fe/src/components/feedMain/FeedMainItem.tsx
+++ b/fe/src/components/feedMain/FeedMainItem.tsx
@@ -60,6 +60,7 @@ export const MainFeedItem = forwardRef<HTMLLIElement, Props>(
         <FeedAction
           feedId={feed.id}
           likeCount={feed.likeCount}
+          isLiked={feed.isLiked}
           commentCount={feed.commentCount}
           onClickCommentIcon={handleOpenDetailFeed}
         />

--- a/fe/src/components/profileUserInfo/ProfileUserInfo.tsx
+++ b/fe/src/components/profileUserInfo/ProfileUserInfo.tsx
@@ -1,5 +1,7 @@
 import { styled } from 'styled-components';
 import { media } from 'styles/mediaQuery';
+import { useAuthState } from 'hooks/auth/useAuth';
+import { generateDefaultUserImage } from 'utils/generateDefaultUserImage';
 import { Badge } from '../common/badge/Badge';
 import { Button } from '../common/button/Button';
 import { CollectableAddIcon, UserPlusIcon } from '../common/icon/icons';
@@ -15,16 +17,21 @@ const MOCK_BADGE = {
 };
 
 export const ProfileUserInfo: React.FC<Props> = ({ member }) => {
+  const { userInfo } = useAuthState();
+  const isAuthor = member.id === userInfo.id;
+
   const handleAddCollection = () => {};
   const handleEditProfile = () => {};
-
-  // const isAuthor = member.id === '1';
-  const isAuthor = true;
-
   return (
     <Wrapper>
       <ContentLeft>
-        <UserImageEdit imageUrl={member.imageUrl} />
+        <UserImageEdit
+          member={member}
+          isAuthor={isAuthor}
+          imageUrl={
+            member.profileImageUrl || generateDefaultUserImage(member.id)
+          }
+        />
         <Column>
           <ContentHeader>
             <p>{member.nickname}</p>
@@ -97,6 +104,7 @@ const ContentWrapper = styled(Flex)`
 const ContentLeft = styled(Flex)`
   justify-content: center;
   align-items: center;
+  height: fit-content;
   gap: 32px;
 
   ${media.xs} {

--- a/fe/src/hooks/useImageUpload.ts
+++ b/fe/src/hooks/useImageUpload.ts
@@ -1,0 +1,63 @@
+import { useRef, useState } from 'react';
+import { useToast } from 'recoil/toast/useToast';
+import { usePostImage } from 'service/queries/imageUpload';
+
+type useImageUploadType = {
+  type: 'feed' | 'user';
+  initialUrl?: string;
+  callbackFn?: () => void;
+};
+
+export const useImageUpload = ({ type, initialUrl }: useImageUploadType) => {
+  const toast = useToast();
+  const { mutate: imageMutate } = usePostImage(type);
+  const [imageData, setImageData] = useState({
+    id: '',
+    url: initialUrl,
+  });
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleImageClick = () => {
+    if (inputRef.current) {
+      inputRef.current.click();
+    }
+  };
+
+  const handleUploadImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    const ALLOWED_TYPES = ['image/png', 'image/jpg', 'image/jpeg'];
+    const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 2; // 2MB
+
+    if (!ALLOWED_TYPES.includes(file.type) || file.size > MAX_FILE_SIZE_BYTES) {
+      toast.noti(
+        '이미지는 2MB 이하의 png, jpg, jpeg 파일만 업로드 가능합니다.'
+      );
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    imageMutate(formData, {
+      onSuccess: (res) => {
+        console.log(res, ' now res');
+        setImageData(res);
+        // onEditMenuImage(menuId, res.id);
+        // onEditMenuImage(menuId, imageData.id);
+        // callbackFn();
+      },
+    });
+
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  };
+
+  return { inputRef, handleImageClick, handleUploadImage, imageData };
+};

--- a/fe/src/hooks/useMenuItem.ts
+++ b/fe/src/hooks/useMenuItem.ts
@@ -1,17 +1,20 @@
 import { useState, useEffect } from 'react';
+import { useToast } from 'recoil/toast/useToast';
 
 const DEFAULT_MENU_ITEM = {
   id: self.crypto.randomUUID(),
-  imageUrl: '1', // 여기 바꾸기
+  image: {
+    id: '',
+    url: '',
+  },
   menu: {
     name: '',
     rating: 0,
   },
 };
 
-// export const useMenuItem = (initialMenuItems: FeedImage[]) => {
 export const useMenuItem = (initialMenuItems?: FeedImage[]) => {
-  // const [menuItems, setMenuItems] = useState(initialMenuItems);
+  const toast = useToast();
   const [menuItems, setMenuItems] = useState(
     initialMenuItems || [DEFAULT_MENU_ITEM]
   );
@@ -22,7 +25,7 @@ export const useMenuItem = (initialMenuItems?: FeedImage[]) => {
 
   const handleAddMenuItem = () => {
     if (menuItems.length >= 3) {
-      console.log(`3개이상 등록불가`);
+      toast.noti('3개 이상 등록할 수 없어요.');
       return;
     }
     const newItem = { ...DEFAULT_MENU_ITEM, id: self.crypto.randomUUID() };
@@ -32,6 +35,7 @@ export const useMenuItem = (initialMenuItems?: FeedImage[]) => {
   const handleRemoveMenuItem = (id: string) => {
     if (menuItems.length === 1) {
       console.log('1개 이상 필수');
+      toast.noti('1개 이상 등록해주세요.');
       return;
     }
     const newItems = menuItems.filter((item) => item.id !== id);
@@ -49,6 +53,17 @@ export const useMenuItem = (initialMenuItems?: FeedImage[]) => {
     setMenuItems(newItems);
   };
 
+  const updateImage = (id: string, updates: Partial<ImageType>) => {
+    const newItems = menuItems.map((item) =>
+      item.id === id ? { ...item, image: { ...item.image, ...updates } } : item
+    );
+    setMenuItems(newItems);
+  };
+
+  const handleEditMenuImage = (id: string, image: ImageType) => {
+    updateImage(id, image);
+  };
+
   const handleEditMenuName = (id: string, name: string) => {
     updateMenu(id, { name });
   };
@@ -61,6 +76,7 @@ export const useMenuItem = (initialMenuItems?: FeedImage[]) => {
     menuItems,
     handleAddMenuItem,
     handleRemoveMenuItem,
+    handleEditMenuImage,
     handleEditMenuName,
     handleEditStarRating,
   };

--- a/fe/src/pages/DetailFeedPage.tsx
+++ b/fe/src/pages/DetailFeedPage.tsx
@@ -6,13 +6,13 @@ import { styled } from 'styled-components';
 import { customScrollStyle } from 'styles/customStyle';
 import { media } from 'styles/mediaQuery';
 import { CommentList } from 'components/comment/CommentList';
-import { CommentInputContainer } from 'components/commentInput/CommentInputContainer';
+import { CommentInput } from 'components/commentInput/CommentInput';
 import { Badge } from 'components/common/badge/Badge';
 import { Carousel } from 'components/common/carousel/Carousel';
 import { Dim } from 'components/common/dim/Dim';
 import { FeedAction } from 'components/common/feedAction/FeedAction';
 import { FeedUserInfo } from 'components/common/feedUserInfo/FeedUserInfo';
-import { useModal } from 'components/common/modal/Modal';
+import { useModal } from 'components/common/modal/useModal';
 import { CommentSkeleton } from 'components/common/skeleton/CommentSkeleton';
 import { DeferredComponent } from 'components/common/skeleton/DeferredComponent';
 import { useInput } from 'hooks/useInput';
@@ -25,7 +25,7 @@ export const DetailFeedModalPage = () => {
   const { closeModal } = useModal<'commentAlert'>();
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  const { mutate: commentMutate } = usePostComment(feedId);
+  const { mutate: commentMutate } = usePostComment();
   const { navigateToHome } = usePageNavigator();
   const { value, handleChange, isValid } = useInput({
     validator: (value) =>
@@ -88,7 +88,7 @@ export const DetailFeedModalPage = () => {
                 commentCount={feed?.commentCount}
               />
               <CommentContainer>
-                <CommentInputContainer
+                <CommentInput
                   value={value}
                   limitedLength={200}
                   onChangeValue={handleChange}

--- a/fe/src/pages/NewFeedPage.tsx
+++ b/fe/src/pages/NewFeedPage.tsx
@@ -34,6 +34,7 @@ export const NewFeedModalPage = () => {
     handleEditMenuName,
     handleEditStarRating,
   } = useMenuItem(feedDetailData?.images);
+
   console.log('feedDetailData', feedDetailData?.images);
   const {
     value: locationName,
@@ -59,19 +60,10 @@ export const NewFeedModalPage = () => {
   }, [feedDetailData]);
 
   const handleSubmit = () => {
-    // console.log({
-    //   location: locationName,
-    //   images: menuItems.map(({ imageId, menu }) => ({
-    //     imageId,
-    //     menu,
-    //   })),
-    //   storeMood: selectedBadgeList.map((badge) => badge.id),
-    //   review: reviewValue,
-    // });
     feedMutate({
       location: locationName,
-      images: menuItems.map(({ imageId, menu }) => ({
-        imageId,
+      images: menuItems.map(({ image, menu }) => ({
+        imageId: image.id,
         menu,
       })),
       storeMood: selectedBadgeList.map((badge) => badge.id),

--- a/fe/src/service/axios/auth/comment/like.ts
+++ b/fe/src/service/axios/auth/comment/like.ts
@@ -10,3 +10,23 @@ export const deleteCommentLikeStatus = async (id: string) => {
   const { data } = await privateApi.delete(END_POINT.commentLike(id));
   return data;
 };
+
+export const postReplyLikeStatus = async ({
+  commentId,
+  replyId,
+}: ReplyLike) => {
+  const { data } = await privateApi.post(
+    END_POINT.replyLike({ commentId, replyId })
+  );
+  return data;
+};
+
+export const deleteReplyLikeStatus = async ({
+  commentId,
+  replyId,
+}: ReplyLike) => {
+  const { data } = await privateApi.delete(
+    END_POINT.replyLike({ commentId, replyId })
+  );
+  return data;
+};

--- a/fe/src/service/axios/feed/imageUpload.ts
+++ b/fe/src/service/axios/feed/imageUpload.ts
@@ -1,0 +1,7 @@
+import { END_POINT } from 'service/constants/endpoint';
+import { multiFormApi } from '../fetcher';
+
+export const postFeedImage = async (file: FormData) => {
+  const { data } = await multiFormApi.post(END_POINT.imageUpload('feed'), file);
+  return data;
+};

--- a/fe/src/service/axios/profile/imageUpload.ts
+++ b/fe/src/service/axios/profile/imageUpload.ts
@@ -1,0 +1,7 @@
+import { END_POINT } from 'service/constants/endpoint';
+import { multiFormApi } from '../fetcher';
+
+export const postUserImage = async (file: FormData) => {
+  const { data } = await multiFormApi.post(END_POINT.imageUpload('user'), file);
+  return data;
+};

--- a/fe/src/service/axios/profile/profile.ts
+++ b/fe/src/service/axios/profile/profile.ts
@@ -5,3 +5,11 @@ export const getProfile = async (memberId?: string) => {
   const { data } = await privateApi.get(END_POINT.member(memberId));
   return data;
 };
+
+export const patchProfileImage = async (
+  memberId: string,
+  body: ProfileImageBody
+) => {
+  const { data } = await privateApi.patch(END_POINT.member(memberId), body);
+  return data;
+};

--- a/fe/src/service/constants/endpoint.ts
+++ b/fe/src/service/constants/endpoint.ts
@@ -5,9 +5,13 @@ export const END_POINT = {
   tasteMood: `/members/taste-moods`,
   storeMood: `/feeds/store-moods`,
   feedLike: (id: string) => `/feeds/${id}/likes`,
-  commentLike: (id: string) => `/comments/${id}/hearts`,
+  commentLike: (id: string) => `/comments/${id}/likes`,
+  replyLike: ({ commentId, replyId }: ReplyLike) =>
+    `comments/${commentId}/replies/${replyId}/likes`,
   member: (id?: string) => (id ? `/members/${id}` : `/members`),
   feed: (id?: string) => (id ? `/feeds/${id}` : `/feeds`),
   comment: (id?: string) => (id ? `/comments/${id}` : `/comments`),
   reply: (id: string) => `/comments/${id}/replies`,
+  imageUpload: (type: 'feed' | 'user') =>
+    type === 'feed' ? `/images/feeds` : `/images/members`,
 };

--- a/fe/src/service/queries/auth.ts
+++ b/fe/src/service/queries/auth.ts
@@ -68,12 +68,10 @@ export const useLogout = () => {
 export const useRegister = () => {
   const toast = useToast();
   const navigate = useNavigate();
-  // const { navigateToLogin } = usePageNavigator();
 
   return useMutation({
     mutationFn: (body: RegisterBody) => fetchRegister(body),
     onSuccess: () => {
-      // navigateToLogin();
       navigate(PATH.LOGIN, { replace: true });
     },
     onError: (error: AxiosError<CustomErrorResponse>) => {

--- a/fe/src/service/queries/auth.ts
+++ b/fe/src/service/queries/auth.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { jwtDecode } from 'jwt-decode';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useToast } from 'recoil/toast/useToast';
 import {
   fetchLogin,
@@ -19,9 +19,10 @@ import { PATH } from 'constants/path';
 
 export const useLogin = () => {
   const toast = useToast();
-  const { navigateToPath } = usePageNavigator();
+  const navigate = useNavigate();
   const location = useLocation();
   const from = location.state?.redirectedFrom?.pathname || PATH.HOME;
+
   //  사용자가 로그인 전에 접근하려고 했던 경로
 
   return useMutation({
@@ -33,7 +34,7 @@ export const useLogin = () => {
       setAccessToken(accessToken);
       setRefreshToken(refreshToken);
       setUserInfo(JSON.stringify(payload));
-      navigateToPath(from);
+      navigate(from, { replace: true });
 
       toast.success('로그인 되었습니다.');
     },
@@ -66,12 +67,14 @@ export const useLogout = () => {
 
 export const useRegister = () => {
   const toast = useToast();
-  const { navigateToLogin } = usePageNavigator();
+  const navigate = useNavigate();
+  // const { navigateToLogin } = usePageNavigator();
 
   return useMutation({
     mutationFn: (body: RegisterBody) => fetchRegister(body),
     onSuccess: () => {
-      navigateToLogin();
+      // navigateToLogin();
+      navigate(PATH.LOGIN, { replace: true });
     },
     onError: (error: AxiosError<CustomErrorResponse>) => {
       const errorData = error?.response?.data;

--- a/fe/src/service/queries/comment.ts
+++ b/fe/src/service/queries/comment.ts
@@ -18,7 +18,8 @@ import { QUERY_KEY } from 'service/constants/queryKey';
 export const useGetComments = (id: string) => {
   const { data, hasNextPage, status, isLoading, fetchNextPage, refetch } =
     useInfiniteQuery({
-      queryKey: [QUERY_KEY.comments, id],
+      queryKey: [QUERY_KEY.comments],
+      // queryKey: [QUERY_KEY.comments, id],
       queryFn: ({ pageParam = 0 }) => getAllComments(pageParam, 10, id),
       getNextPageParam: (lastPage) => {
         return lastPage.last ? undefined : lastPage.number + 1;
@@ -40,14 +41,15 @@ export const useGetComments = (id: string) => {
   };
 };
 
-export const usePostComment = (id: string) => {
+export const usePostComment = () => {
   const queryClient = useQueryClient();
   const toast = useToast();
 
   return useMutation({
     mutationFn: (body: NewCommentBody) => postNewComment(body),
     onSuccess: () => {
-      queryClient.invalidateQueries([QUERY_KEY.comments, id]);
+      // queryClient.invalidateQueries([QUERY_KEY.comments, id]);
+      queryClient.invalidateQueries([QUERY_KEY.comments]);
     },
     onError: (error: AxiosError<CustomErrorResponse>) => {
       const errorData = error?.response?.data;

--- a/fe/src/service/queries/feed.ts
+++ b/fe/src/service/queries/feed.ts
@@ -15,7 +15,6 @@ import {
   putEditFeed,
 } from 'service/axios/feed/feed';
 import { QUERY_KEY } from 'service/constants/queryKey';
-// import { usePageNavigator } from 'hooks/usePageNavigator';
 import { PATH } from 'constants/path';
 
 export const useAllFeeds = () => {
@@ -46,7 +45,6 @@ export const useFeedDetail = (id: string) =>
   });
 
 export const useFeedEditor = (id?: string) => {
-  // const { navigateToHome } = usePageNavigator();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const toast = useToast();
@@ -57,8 +55,14 @@ export const useFeedEditor = (id?: string) => {
     onSuccess: () => {
       if (id) {
         // edit 성공시 detail로 이동
-        queryClient.invalidateQueries([QUERY_KEY.feedDetail, id]); // invalidate 꼭해야하는지 확인하기
-        navigate(`${PATH.DETAIL_FEED}/${id}`, { replace: true });
+        queryClient.invalidateQueries([QUERY_KEY.feedDetail, id]);
+        queryClient.invalidateQueries([QUERY_KEY.allFeeds]);
+
+        toast.success('피드를 수정했습니다.');
+        navigate(`${PATH.DETAIL_FEED}/${id}`, {
+          state: { background: 'detailFeed' },
+          replace: true,
+        });
       } else {
         // post 성공시 home으로 이동
         queryClient.invalidateQueries([QUERY_KEY.allFeeds]);

--- a/fe/src/service/queries/imageUpload.ts
+++ b/fe/src/service/queries/imageUpload.ts
@@ -1,0 +1,18 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useToast } from 'recoil/toast/useToast';
+import { postFeedImage } from 'service/axios/feed/imageUpload';
+import { postUserImage } from 'service/axios/profile/imageUpload';
+
+export const usePostImage = (type: 'feed' | 'user') => {
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: type === 'feed' ? postFeedImage : postUserImage,
+
+    onError: (error: AxiosError<CustomErrorResponse>) => {
+      const errorData = error?.response?.data;
+      errorData && toast.error(errorData.message);
+    },
+  });
+};

--- a/fe/src/service/queries/like.ts
+++ b/fe/src/service/queries/like.ts
@@ -3,49 +3,137 @@ import { AxiosError } from 'axios';
 import { useToast } from 'recoil/toast/useToast';
 import {
   deleteCommentLikeStatus,
+  deleteReplyLikeStatus,
   postCommentLikeStatus,
+  postReplyLikeStatus,
 } from 'service/axios/auth/comment/like';
 import 'service/axios/feed/feed';
 import { deleteLikeStatus, postLikeStatus } from 'service/axios/like/like';
 import { QUERY_KEY } from 'service/constants/queryKey';
 
-// export const usePostLike = (urlParam?: string) => {
+// interface FeedLikeContext {
+//   previousData: MainFeed | MainFeed[] | undefined;
+// }
+
+// export const usePostFeedLike = (urlParam?: string) => {
 //   const queryClient = useQueryClient();
 //   const toast = useToast();
 
 //   return useMutation({
-//     mutationFn: (body: LikeBody) => postLikeStatus(body),
-//     onMutate: async (body: LikeBody) => {
-//       console.log(urlParam); // TODO urlParam이 없으면 mainFeed, 있으면 feedDetail => 갱신해야할 쿼리가 다름
+//     mutationFn: (id: string) => postLikeStatus(id),
+//     onMutate: async (id: string) => {
+//       urlParam
+//         ? await queryClient.cancelQueries([QUERY_KEY.feedDetail, id])
+//         : await queryClient.cancelQueries([QUERY_KEY.allFeeds]);
 
-//       await queryClient.cancelQueries([QUERY_KEY.feedDetail, body.feedId]);
+//       const previousData = urlParam
+//         ? queryClient.getQueryData<MainFeed | undefined>([
+//             QUERY_KEY.feedDetail,
+//             id,
+//           ])
+//         : queryClient.getQueryData<MainFeed[] | undefined>([
+//             QUERY_KEY.allFeeds,
+//           ]);
 
-//       const previousData = queryClient.getQueryData<MainFeed | undefined>([
-//         QUERY_KEY.feedDetail,
-//         body.feedId,
-//       ]);
-
-//       if (previousData) {
-//         const updatedData = {
-//           ...previousData,
-//           isLiked: !previousData.isLiked,
-//           likeCount: previousData.isLiked
-//             ? previousData.likeCount - 1
-//             : previousData.likeCount + 1,
-//         };
-
-//         queryClient.setQueryData(
-//           [QUERY_KEY.feedDetail, body.feedId],
-//           updatedData
-//         );
-//       }
+//       queryClient.setQueryData(
+//         urlParam ? [QUERY_KEY.feedDetail, id] : [QUERY_KEY.allFeeds],
+//         (oldData: MainFeed | undefined) => {
+//           if (oldData) {
+//             return {
+//               ...oldData,
+//               isLiked: true,
+//               likeCount: oldData.likeCount + 1,
+//             };
+//           }
+//           return oldData;
+//         }
+//       );
 
 //       return { previousData };
 //     },
-//     onError: (error: AxiosError<CustomErrorResponse>) => {
+//     onSuccess: (id: string) => {
+//       // urlParam
+//       //   ? queryClient.invalidateQueries([QUERY_KEY.feedDetail, id])
+//       //   : queryClient.invalidateQueries([QUERY_KEY.allFeeds]);
+
+//       queryClient.invalidateQueries([QUERY_KEY.feedDetail, id]);
+//       queryClient.invalidateQueries([QUERY_KEY.allFeeds]);
+//     },
+//     onError: (
+//       error: AxiosError<CustomErrorResponse>,
+//       context: FeedLikeContext
+//     ) => {
 //       const errorData = error?.response?.data;
 
 //       errorData && toast.error(errorData.message);
+
+//       if (context?.previousData) {
+//         queryClient.setQueryData(
+//           urlParam
+//             ? [QUERY_KEY.feedDetail, context?.previousData]
+//             : [QUERY_KEY.allFeeds],
+//           context?.previousData
+//         );
+//       }
+//     },
+//   });
+// };
+
+// export const useDeleteFeedLike = (urlParam?: string) => {
+//   const queryClient = useQueryClient();
+//   const toast = useToast();
+
+//   return useMutation({
+//     mutationFn: (id: string) => deleteLikeStatus(id),
+//     onMutate: async (id: string) => {
+//       urlParam
+//         ? await queryClient.cancelQueries([QUERY_KEY.feedDetail, id])
+//         : await queryClient.cancelQueries([QUERY_KEY.allFeeds]);
+
+//       const previousData = queryClient.getQueryData<MainFeed | undefined>([
+//         QUERY_KEY.feedDetail,
+//         id,
+//       ]);
+
+//       queryClient.setQueryData(
+//         [QUERY_KEY.feedDetail, id],
+//         (oldData: MainFeed | undefined) => {
+//           if (oldData) {
+//             return {
+//               ...oldData,
+//               likeCount: oldData.likeCount > 0 ? oldData.likeCount - 1 : 0,
+//               isLiked: false,
+//             };
+//           }
+//           return oldData;
+//         }
+//       );
+
+//       return { previousData };
+//     },
+//     onSuccess: (id: string) => {
+//       // urlParam
+//       //   ? queryClient.invalidateQueries([QUERY_KEY.feedDetail, id])
+//       //   : queryClient.invalidateQueries([QUERY_KEY.allFeeds]);
+//       queryClient.invalidateQueries([QUERY_KEY.feedDetail, id]);
+//       queryClient.invalidateQueries([QUERY_KEY.allFeeds]);
+//     },
+//     onError: (
+//       error: AxiosError<CustomErrorResponse>,
+//       context: FeedLikeContext
+//     ) => {
+//       const errorData = error?.response?.data;
+
+//       errorData && toast.error(errorData.message);
+
+//       if (context?.previousData) {
+//         queryClient.setQueryData(
+//           urlParam
+//             ? [QUERY_KEY.feedDetail, context?.previousData]
+//             : [QUERY_KEY.allFeeds],
+//           context?.previousData
+//         );
+//       }
 //     },
 //   });
 // };
@@ -56,30 +144,9 @@ export const usePostFeedLike = (urlParam?: string) => {
 
   return useMutation({
     mutationFn: (id: string) => postLikeStatus(id),
-    onMutate: async (id: string) => {
-      console.log(urlParam); // TODO urlParam이 없으면 mainFeed, 있으면 feedDetail => 갱신해야할 쿼리가 다름
-      await queryClient.cancelQueries([QUERY_KEY.feedDetail, id]);
-
-      const previousData = queryClient.getQueryData<MainFeed | undefined>([
-        QUERY_KEY.feedDetail,
-        id,
-      ]);
-
-      queryClient.setQueryData(
-        [QUERY_KEY.feedDetail, id],
-        (oldData: MainFeed | undefined) => {
-          if (oldData) {
-            return {
-              ...oldData,
-              isLiked: true,
-              likeCount: oldData.likeCount + 1,
-            };
-          }
-          return oldData;
-        }
-      );
-
-      return { previousData };
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERY_KEY.feedDetail, urlParam]);
+      queryClient.invalidateQueries([QUERY_KEY.allFeeds]);
     },
     onError: (error: AxiosError<CustomErrorResponse>) => {
       const errorData = error?.response?.data;
@@ -95,30 +162,10 @@ export const useDeleteFeedLike = (urlParam?: string) => {
 
   return useMutation({
     mutationFn: (id: string) => deleteLikeStatus(id),
-    onMutate: async (id: string) => {
-      console.log(urlParam);
-      await queryClient.cancelQueries([QUERY_KEY.feedDetail, id]);
 
-      const previousData = queryClient.getQueryData<MainFeed | undefined>([
-        QUERY_KEY.feedDetail,
-        id,
-      ]);
-
-      queryClient.setQueryData(
-        [QUERY_KEY.feedDetail, id],
-        (oldData: MainFeed | undefined) => {
-          if (oldData) {
-            return {
-              ...oldData,
-              likeCount: oldData.likeCount > 0 ? oldData.likeCount - 1 : 0,
-              isLiked: false,
-            };
-          }
-          return oldData;
-        }
-      );
-
-      return { previousData };
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERY_KEY.feedDetail, urlParam]);
+      queryClient.invalidateQueries([QUERY_KEY.allFeeds]);
     },
     onError: (error: AxiosError<CustomErrorResponse>) => {
       const errorData = error?.response?.data;
@@ -128,39 +175,98 @@ export const useDeleteFeedLike = (urlParam?: string) => {
   });
 };
 
-export const usePostCommentLike = ({ isReply }: { isReply: boolean }) => {
+// export const usePostCommentLike = ({ isReply }: { isReply: boolean }) => {
+//   const queryClient = useQueryClient();
+//   const toast = useToast();
+
+//   return useMutation({
+//     mutationFn: (id: string) => postCommentLikeStatus(id),
+//     onMutate: async (id: string) => {
+//       isReply
+//         ? await queryClient.cancelQueries([QUERY_KEY.replies, id])
+//         : await queryClient.cancelQueries([QUERY_KEY.comments, id]);
+
+//       const previousData = queryClient.getQueryData([QUERY_KEY.feedDetail, id]);
+
+//       queryClient.setQueryData(
+//         [QUERY_KEY.feedDetail, id],
+//         (oldData: CommentItemType | ReplyItemType | undefined) => {
+//           if (oldData) {
+//             return {
+//               ...oldData,
+//               heartCount: oldData.heartCount + 1,
+//               hearted: true,
+//             };
+//           }
+//           return oldData;
+//         }
+//       );
+
+//       return { previousData };
+//     },
+//     onSuccess: (id: string) => {
+//       isReply
+//         ? queryClient.invalidateQueries([QUERY_KEY.replies, id])
+//         : queryClient.cancelQueries([QUERY_KEY.comments, id]);
+//     },
+//     onError: (error: AxiosError<CustomErrorResponse>) => {
+//       const errorData = error?.response?.data;
+
+//       errorData && toast.error(errorData.message);
+//     },
+//   });
+// };
+
+// export const useDeleteCommentLike = ({ isReply }: { isReply: boolean }) => {
+//   const queryClient = useQueryClient();
+//   const toast = useToast();
+
+//   return useMutation({
+//     mutationFn: (id: string) => deleteCommentLikeStatus(id),
+//     onMutate: async (id: string) => {
+//       isReply
+//         ? await queryClient.cancelQueries([QUERY_KEY.replies, id])
+//         : await queryClient.cancelQueries([QUERY_KEY.comments]);
+
+//       const previousData = queryClient.getQueryData([QUERY_KEY.feedDetail, id]);
+
+//       queryClient.setQueryData(
+//         [QUERY_KEY.feedDetail, id],
+//         (oldData: CommentItemType | ReplyItemType | undefined) => {
+//           if (oldData) {
+//             return {
+//               ...oldData,
+//               heartCount: oldData.heartCount > 0 ? oldData.heartCount - 1 : 0,
+//               hearted: false,
+//             };
+//           }
+//           return oldData;
+//         }
+//       );
+
+//       return { previousData };
+//     },
+//     onSuccess: (id: string) => {
+//       isReply
+//         ? queryClient.invalidateQueries([QUERY_KEY.replies, id])
+//         : queryClient.cancelQueries([QUERY_KEY.comments, id]);
+//     },
+//     onError: (error: AxiosError<CustomErrorResponse>) => {
+//       const errorData = error?.response?.data;
+
+//       errorData && toast.error(errorData.message);
+//     },
+//   });
+// };
+
+export const usePostCommentLike = () => {
   const queryClient = useQueryClient();
   const toast = useToast();
 
   return useMutation({
     mutationFn: (id: string) => postCommentLikeStatus(id),
-    onMutate: async (id: string) => {
-      isReply
-        ? await queryClient.cancelQueries([QUERY_KEY.replies, id])
-        : await queryClient.cancelQueries([QUERY_KEY.comments, id]);
-
-      const previousData = queryClient.getQueryData([QUERY_KEY.feedDetail, id]);
-
-      queryClient.setQueryData(
-        [QUERY_KEY.feedDetail, id],
-        (oldData: CommentItemType | ReplyItemType | undefined) => {
-          if (oldData) {
-            return {
-              ...oldData,
-              heartCount: oldData.heartCount + 1,
-              hearted: true,
-            };
-          }
-          return oldData;
-        }
-      );
-
-      return { previousData };
-    },
-    onSuccess: (id: string) => {
-      isReply
-        ? queryClient.invalidateQueries([QUERY_KEY.replies, id])
-        : queryClient.cancelQueries([QUERY_KEY.comments, id]);
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERY_KEY.comments]);
     },
     onError: (error: AxiosError<CustomErrorResponse>) => {
       const errorData = error?.response?.data;
@@ -170,39 +276,63 @@ export const usePostCommentLike = ({ isReply }: { isReply: boolean }) => {
   });
 };
 
-export const useDeleteCommentLike = ({ isReply }: { isReply: boolean }) => {
+export const useDeleteCommentLike = () => {
   const queryClient = useQueryClient();
   const toast = useToast();
 
   return useMutation({
     mutationFn: (id: string) => deleteCommentLikeStatus(id),
-    onMutate: async (id: string) => {
-      isReply
-        ? await queryClient.cancelQueries([QUERY_KEY.replies, id])
-        : await queryClient.cancelQueries([QUERY_KEY.comments]);
 
-      const previousData = queryClient.getQueryData([QUERY_KEY.feedDetail, id]);
-
-      queryClient.setQueryData(
-        [QUERY_KEY.feedDetail, id],
-        (oldData: CommentItemType | ReplyItemType | undefined) => {
-          if (oldData) {
-            return {
-              ...oldData,
-              heartCount: oldData.heartCount > 0 ? oldData.heartCount - 1 : 0,
-              hearted: false,
-            };
-          }
-          return oldData;
-        }
-      );
-
-      return { previousData };
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERY_KEY.comments]);
     },
-    onSuccess: (id: string) => {
-      isReply
-        ? queryClient.invalidateQueries([QUERY_KEY.replies, id])
-        : queryClient.cancelQueries([QUERY_KEY.comments, id]);
+    onError: (error: AxiosError<CustomErrorResponse>) => {
+      const errorData = error?.response?.data;
+
+      errorData && toast.error(errorData.message);
+    },
+  });
+};
+
+export const usePostReplyLike = () => {
+    // 대댓 id 넘겨주기
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: ({ commentId, replyId }: ReplyLike) =>
+      postReplyLikeStatus({
+        commentId,
+        replyId,
+      }),
+    onSuccess: ({ commentId }: ReplyLike) => {
+      console.log('commentId', commentId);
+
+      queryClient.invalidateQueries([QUERY_KEY.comments]);
+      queryClient.refetchQueries([QUERY_KEY.replies]); // 키값에 아이디 넣어줘야함
+    },
+    onError: (error: AxiosError<CustomErrorResponse>) => {
+      const errorData = error?.response?.data;
+
+      errorData && toast.error(errorData.message);
+    },
+  });
+};
+
+export const useDeleteReplyLike = () => {
+  // 대댓 id 넘겨주기
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: ({ commentId, replyId }: ReplyLike) =>
+      deleteReplyLikeStatus({
+        commentId,
+        replyId,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERY_KEY.comments]);
+      queryClient.refetchQueries([QUERY_KEY.replies]); // 키값에 아이디 넣어줘야함
     },
     onError: (error: AxiosError<CustomErrorResponse>) => {
       const errorData = error?.response?.data;

--- a/fe/src/service/queries/profile.ts
+++ b/fe/src/service/queries/profile.ts
@@ -1,10 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
-import { getProfile } from 'service/axios/profile/profile';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useToast } from 'recoil/toast/useToast';
+import { getProfile, patchProfileImage } from 'service/axios/profile/profile';
 import { QUERY_KEY } from 'service/constants/queryKey';
 
 export const useGetProfile = (id?: string) => {
   return useQuery({
-    queryKey: [QUERY_KEY.profile, id],
+    queryKey: [QUERY_KEY.profile],
     queryFn: async () => {
       const { myFeeds, ...memberProfileData } = await getProfile(id);
       return { myFeeds, memberProfileData };
@@ -12,3 +14,19 @@ export const useGetProfile = (id?: string) => {
     staleTime: Infinity,
   });
 };
+
+export const useEditProfileImage = (id: string) => {
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: (body: ProfileImageBody) => patchProfileImage(id, body),
+    onError: (error: AxiosError<CustomErrorResponse>) => {
+      const errorData = error?.response?.data;
+      console.log('useEditProfileImage error: ', error);
+
+      errorData && toast.error(errorData.message);
+    },
+  });
+};
+
+export const useEditProfile = () => {};

--- a/fe/src/service/queries/reply.ts
+++ b/fe/src/service/queries/reply.ts
@@ -13,7 +13,7 @@ import { QUERY_KEY } from 'service/constants/queryKey';
 export const useGetReplies = (id: string) => {
   const { data, hasNextPage, isFetching, fetchNextPage, refetch } =
     useInfiniteQuery({
-      // queryKey: [QUERY_KEY.replies],
+      // queryKey: [QUERY_KEY.replies], // 대댓글 전체가 렌더링됨
       queryKey: [QUERY_KEY.replies, id],
       queryFn: ({ pageParam = 0 }) => getAllReplies(pageParam, 10, id),
       getNextPageParam: (lastPage) => {

--- a/fe/src/types/comment.d.ts
+++ b/fe/src/types/comment.d.ts
@@ -20,8 +20,8 @@ type CommentItemType = {
   replyCount: number;
 
   // 변경사항
-  heartCount: number;
-  hearted: boolean;
+  likeCount: number;
+  liked: boolean;
 };
 
 type ReplyItemType = Omit<CommentItem, 'hasReply'>;

--- a/fe/src/types/feed.d.ts
+++ b/fe/src/types/feed.d.ts
@@ -14,8 +14,20 @@ type MainFeed = {
 
 type FeedImage = {
   id: string;
-  imageUrl: string;
+  // imageId?: string;
+  // imageUrl?: string;
+  image: ImageType;
   menu: MenuTag;
+};
+
+type ImageType = {
+  id: string;
+  url: string;
+};
+
+type MenuTag = {
+  name: string;
+  rating: number;
 };
 
 type FeedMemberInfo = {
@@ -25,18 +37,13 @@ type FeedMemberInfo = {
   tasteMood: Mood;
 };
 
-type MenuTag = {
-  name: string;
-  rating: number;
-};
-
 type NewFeedBody = {
   location: string;
   review: string;
   storeMood: string[];
   images: {
-    menu: MenuTag;
     imageId: string;
+    menu: MenuTag;
   }[];
 };
 /* TODO. 수정 예정 */

--- a/fe/src/types/like.d.ts
+++ b/fe/src/types/like.d.ts
@@ -1,3 +1,4 @@
-type LikeBody = {
-  feedId: string;
+type ReplyLike = {
+  commentId: string;
+  replyId: string;
 };

--- a/fe/src/types/profile.d.ts
+++ b/fe/src/types/profile.d.ts
@@ -1,14 +1,19 @@
 type ProfileMemberInfo = {
-  memberId: string;
-  imageUrl: string;
+  id: string;
+  profileImageUrl: string;
+  profileImageId: string;
   nickname: string;
   email: string;
-  tasteMood: string;
-  myFeeds: MyFeeds[];
-  // myFeedsCount: number;
+  tasteMoodId: string;
+  feedCount: number;
 };
 
 type MyFeeds = {
   id: string;
   imageUrl: string;
+};
+
+type ProfileImageBody = {
+  profileImageId: string;
+  tasteMoodId: null;
 };

--- a/fe/src/utils/generateDefaultUserImage.ts
+++ b/fe/src/utils/generateDefaultUserImage.ts
@@ -1,0 +1,5 @@
+export const generateDefaultUserImage = (userId: string) => {
+  const defaultUserImage = `https://source.boringavatars.com/beam/${userId}`;
+
+  return defaultUserImage;
+};

--- a/fe/vite.config.ts.timestamp-1702496076404-afa74354b96ab.mjs
+++ b/fe/vite.config.ts.timestamp-1702496076404-afa74354b96ab.mjs
@@ -1,0 +1,15 @@
+// vite.config.ts
+import react from "file:///C:/Users/yjh/foodymoody/fe/node_modules/@vitejs/plugin-react-swc/index.mjs";
+import { defineConfig } from "file:///C:/Users/yjh/foodymoody/fe/node_modules/vite/dist/node/index.js";
+import svgr from "file:///C:/Users/yjh/foodymoody/fe/node_modules/vite-plugin-svgr/dist/index.js";
+import tsconfigPaths from "file:///C:/Users/yjh/foodymoody/fe/node_modules/vite-tsconfig-paths/dist/index.mjs";
+var vite_config_default = defineConfig({
+  plugins: [react(), svgr(), tsconfigPaths()],
+  optimizeDeps: {
+    include: ["emoji-picker-react"]
+  }
+});
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCJDOlxcXFxVc2Vyc1xcXFx5amhcXFxcZm9vZHltb29keVxcXFxmZVwiO2NvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9maWxlbmFtZSA9IFwiQzpcXFxcVXNlcnNcXFxceWpoXFxcXGZvb2R5bW9vZHlcXFxcZmVcXFxcdml0ZS5jb25maWcudHNcIjtjb25zdCBfX3ZpdGVfaW5qZWN0ZWRfb3JpZ2luYWxfaW1wb3J0X21ldGFfdXJsID0gXCJmaWxlOi8vL0M6L1VzZXJzL3lqaC9mb29keW1vb2R5L2ZlL3ZpdGUuY29uZmlnLnRzXCI7aW1wb3J0IHJlYWN0IGZyb20gJ0B2aXRlanMvcGx1Z2luLXJlYWN0LXN3Yyc7XHJcbmltcG9ydCB7IGRlZmluZUNvbmZpZyB9IGZyb20gJ3ZpdGUnO1xyXG5pbXBvcnQgc3ZnciBmcm9tICd2aXRlLXBsdWdpbi1zdmdyJztcclxuaW1wb3J0IHRzY29uZmlnUGF0aHMgZnJvbSAndml0ZS10c2NvbmZpZy1wYXRocyc7XHJcblxyXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoe1xyXG4gIHBsdWdpbnM6IFtyZWFjdCgpLCBzdmdyKCksIHRzY29uZmlnUGF0aHMoKV0sXHJcbiAgb3B0aW1pemVEZXBzOiB7XHJcbiAgICBpbmNsdWRlOiBbJ2Vtb2ppLXBpY2tlci1yZWFjdCddLFxyXG4gIH0sXHJcbn0pO1xyXG4iXSwKICAibWFwcGluZ3MiOiAiO0FBQTBRLE9BQU8sV0FBVztBQUM1UixTQUFTLG9CQUFvQjtBQUM3QixPQUFPLFVBQVU7QUFDakIsT0FBTyxtQkFBbUI7QUFFMUIsSUFBTyxzQkFBUSxhQUFhO0FBQUEsRUFDMUIsU0FBUyxDQUFDLE1BQU0sR0FBRyxLQUFLLEdBQUcsY0FBYyxDQUFDO0FBQUEsRUFDMUMsY0FBYztBQUFBLElBQ1osU0FBUyxDQUFDLG9CQUFvQjtBQUFBLEVBQ2hDO0FBQ0YsQ0FBQzsiLAogICJuYW1lcyI6IFtdCn0K


### PR DESCRIPTION
## Key changes🔧
- 
## To reviewer👋
- 사진 업로드 로직을 훅으로 묶고싶은데 onSuccess후 callback함수 인자에 onSuccess시 response로 오는 값이 들어가야해서 비동기 제어를 하려니 몬가 훅으로 온전히 분리하기 어렵네요 
- 아직 사진 삭제는 고려하지 않았습니다 
  - 메뉴를 삭제할때나 피드를 삭제할때 등 몇가지 케이스를 고민해서 나중에 따로 이슈 파서 진행
- 대댓글 좋아요, 수정에는 아직도 백엔드 연결과 오류가 있습니다 
  - 더 붙잡고 있기엔 pr이 너무 늦어져서 올립니다