### PR TITLE
[FE] Button 컴포넌트 스타일 추가

### DIFF
--- a/fe/src/components/common/button/Button.tsx
+++ b/fe/src/components/common/button/Button.tsx
@@ -2,19 +2,21 @@ import { forwardRef } from 'react';
 import styled from 'styled-components';
 
 type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  size: 's' | 'l';
-  backgroundColor: 'orange' | 'black' | 'white';
+  size: 'xs' | 's' | 'l';
+  backgroundColor: 'orange' | 'black' | 'white' | 'blue500';
   children: React.ReactNode;
   width?: number;
+  shadow?: boolean;
 };
 
 export const Button = forwardRef<HTMLButtonElement, Props>(
-  ({ children, backgroundColor, width, ...props }, ref) => {
+  ({ children, backgroundColor, width, shadow = false, ...props }, ref) => {
     return (
       <Wrapper
         ref={ref}
         $backgroundColor={backgroundColor}
         $width={width}
+        $shadow={shadow}
         {...props}
       >
         {children}
@@ -22,13 +24,16 @@ export const Button = forwardRef<HTMLButtonElement, Props>(
     );
   }
 );
+
 const Wrapper = styled.button<{
-  size: 's' | 'l';
-  $backgroundColor: 'orange' | 'black' | 'white';
+  size: 'xs' | 's' | 'l';
+  $backgroundColor: 'orange' | 'black' | 'white' | 'blue500';
   $width?: number;
+  $shadow?: boolean;
 }>`
   font: ${({ theme: { fonts } }) => fonts.displayM16};
-  height: ${({ size }) => (size === 's' ? '40px' : '56px')};
+  height: ${({ size }) =>
+    size === 's' ? '40px' : size === 'l' ? '56px' : '32px'};
   padding-top: ${({ size }) => (size === 's' ? '8px' : '16px')};
   padding-bottom: ${({ size }) => (size === 's' ? '8px' : '16px')};
   border: 1px solid ${({ theme: { colors } }) => colors.black};
@@ -43,6 +48,8 @@ const Wrapper = styled.button<{
   justify-content: center;
   gap: 8px;
   transition: all 0.3s;
+  box-shadow: ${({ $shadow }) =>
+    $shadow ? '2px 2px 0px 0px #0A0A0A' : 'none'};
 
   &:hover {
     border-color: ${({ theme: { colors } }) => colors.black};


### PR DESCRIPTION
## Key changes🔧
- shadow props 추가 (기본값: false)
- size="xs" 추가 (높이 32px)
  - 원래 사이즈 높이는 size="s" (40px), size="l" (56px)

## To reviewer👋

shadow 넣으면 아래처럼 생김
xs 사이즈는 저희 디자인 해논거에는 없는 사이즈 버튼이긴 한데
모바일로 볼 경우에 s 사이즈 (40px) 짜리 버튼이 좀 커보이는 경향이 있는 것 같아서 
작게 하고 싶을 때 쓰라고 넣었습니다

```js
      <Button size="xs" backgroundColor="blue500" shadow>
        모든 알림 읽기
      </Button>
```


![image](https://github.com/codesquad-members-2023/FoodyMoody-team-06/assets/95265031/4b99e4f8-e6f4-4487-b0a9-80eee696e461)



