### PR TITLE
[FE] react hook form+zod적용, 정보수정기능 연동

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -8,6 +8,7 @@
       "name": "foodymoody",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.3.2",
         "@tanstack/react-query": "^4.36.1",
         "@tanstack/react-query-devtools": "^4.36.1",
         "@types/react-router-dom": "^5.3.3",
@@ -18,13 +19,15 @@
         "jwt-decode": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-hook-form": "^7.49.2",
         "react-loading-skeleton": "^3.3.1",
         "react-router-dom": "^6.16.0",
         "react-slick": "^0.29.0",
         "recoil": "^0.7.7",
         "slick-carousel": "^1.8.1",
         "styled-components": "^6.1.0",
-        "vite-plugin-svgr": "^4.1.0"
+        "vite-plugin-svgr": "^4.1.0",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@tanstack/eslint-plugin-query": "^4.36.1",
@@ -780,6 +783,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.2.tgz",
+      "integrity": "sha512-Tw+GGPnBp+5DOsSg4ek3LCPgkBOuOgS5DsDV7qsWNH9LZc433kgsWICjlsh2J9p04H2K66hsXPPb9qn9ILdUtA==",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3762,6 +3773,22 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.49.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.49.2.tgz",
+      "integrity": "sha512-TZcnSc17+LPPVpMRIDNVITY6w20deMdNi6iehTFLV1x8SqThXGwu93HjlUVU09pzFgZH7qZOvLMM7UYf2ShAHA==",
+      "engines": {
+        "node": ">=18",
+        "pnpm": "8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -4520,6 +4547,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/fe/package.json
+++ b/fe/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.3.2",
     "@tanstack/react-query": "^4.36.1",
     "@tanstack/react-query-devtools": "^4.36.1",
     "@types/react-router-dom": "^5.3.3",
@@ -20,13 +21,15 @@
     "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hook-form": "^7.49.2",
     "react-loading-skeleton": "^3.3.1",
     "react-router-dom": "^6.16.0",
     "react-slick": "^0.29.0",
     "recoil": "^0.7.7",
     "slick-carousel": "^1.8.1",
     "styled-components": "^6.1.0",
-    "vite-plugin-svgr": "^4.1.0"
+    "vite-plugin-svgr": "^4.1.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^4.36.1",

--- a/fe/src/components/common/headerMob/HeaderMob.tsx
+++ b/fe/src/components/common/headerMob/HeaderMob.tsx
@@ -8,9 +8,15 @@ import { GearIcon, LogoLarge, SantaHat } from '../icon/icons';
 import { PATH } from 'constants/path';
 
 export const HeaderMob: React.FC = () => {
-  const { navigateToHome,navigateToSetting } = usePageNavigator();
+  const { navigateToHome, navigateToSetting } = usePageNavigator();
   const currentLocation = useLocation();
-  const isProfilePage = currentLocation.pathname === PATH.PROFILE;
+  const allowedPaths = [
+    PATH.PROFILE,
+    PATH.PASSWORD,
+    PATH.PROFILE_EDIT,
+    PATH.ACCOUNT,
+  ];
+  const accessToSetting = allowedPaths.includes(currentLocation.pathname);
 
   return (
     <Wrapper>
@@ -19,7 +25,7 @@ export const HeaderMob: React.FC = () => {
         <LogoLarge onClick={navigateToHome} />
         <ContentRight>
           <NotiIcon />
-          {isProfilePage && <GearIcon  onClick={navigateToSetting}/>}
+          {accessToSetting && <GearIcon onClick={navigateToSetting} />}
         </ContentRight>
       </FlexRowBox>
     </Wrapper>

--- a/fe/src/components/common/input/Input.tsx
+++ b/fe/src/components/common/input/Input.tsx
@@ -143,8 +143,7 @@ const RectangleWrapper = styled(BaseWrapper)`
     ${({ $isFocused, $isError, theme: { colors } }) =>
       $isFocused && $isError ? colors.pink : colors.black};
   border-radius: 4px;
-  padding: ${({ $isFocused }) =>
-    $isFocused ? '20px 20px 4px 20px' : '12px 20px '};
+  padding: 12px 10px;
 
   &:focus-within {
     border-color: ${({ $isError, theme: { colors } }) =>

--- a/fe/src/components/common/userImage/UserImageEdit.tsx
+++ b/fe/src/components/common/userImage/UserImageEdit.tsx
@@ -10,14 +10,12 @@ import { EditIcon } from '../icon/icons';
 import { UserImage } from './UserImage';
 
 type Props = {
-
   isAuthor: boolean;
   imageId?: string;
   imageUrl?: string;
 };
 
 export const UserImageEdit: React.FC<Props> = ({
-
   isAuthor,
   imageId,
   imageUrl,
@@ -28,8 +26,7 @@ export const UserImageEdit: React.FC<Props> = ({
   });
   const { userInfo } = useAuthState();
   const { mutate: imageMutate } = usePostImage('user');
-  const { mutate: profileMutate } = useEditProfileImage(userInfo.id);
-
+  const { mutate: profileImageMutate } = useEditProfileImage(userInfo.id);
 
   const toast = useToast();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -68,7 +65,11 @@ export const UserImageEdit: React.FC<Props> = ({
         console.log(res, ' now res');
         setImageData(res);
         //여기에 프로필 수정 mutate하기
-        profileMutate({ profileImageId: res.id, tasteMoodId: null });
+        profileImageMutate({
+          nickname: null,
+          tasteMoodId: null,
+          profileImageId: res.id,
+        });
       },
     });
 

--- a/fe/src/components/login/Login.tsx
+++ b/fe/src/components/login/Login.tsx
@@ -1,72 +1,61 @@
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useLogin } from 'service/queries/auth';
 import { styled } from 'styled-components';
 import { Button } from 'components/common/button/Button';
 import { ValidatedInput } from 'components/validatedInput/ValidatedInput';
-import { useInput } from 'hooks/useInput';
+import { useLoginForm } from 'hooks/useLoginForm/useLoginForm';
+import { LoginSchemaType } from 'hooks/useLoginForm/useLoginFormSchema';
 
 export const Login: React.FC = () => {
-  const { mutate: loginMutate, isLoading } = useLogin();
-  const passwordRef = useRef<HTMLInputElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const {
-    value: idValue,
-    handleChange: handleIdChange,
-    helperText: idHelperText,
-    isValid: isIdValid,
-  } = useInput({
-    initialValue: '',
-    validator: (value) =>
-      /^[a-zA-Z0-9._-]+@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,6}$/.test(value),
-    helperText: '이메일 형식에 맞게 입력해주세요',
-  });
+  const { mutate: loginMutate } = useLogin();
+  const passwordReff = useRef<HTMLInputElement>(null);
+  const buttonReff = useRef<HTMLButtonElement>(null);
 
-  const {
-    value: passwordValue,
-    handleChange: handlePasswordChange,
-    helperText: passwordHelperText,
-    isValid: isPasswordValid,
-  } = useInput({
-    initialValue: '',
-    validator: (value) => value.trim().length > 7,
-    helperText: '비밀번호는 8자 이상 입력해주세요',
-  });
+  const { register, handleSubmit, state, errorItem, reset } = useLoginForm();
 
-  const handleSubmit = () => {
-    const loginData = {
-      email: idValue,
-      password: passwordValue,
+  useEffect(() => {
+    if (state.isSubmitSuccessful) {
+      reset();
+    }
+  }, [state.isSubmitSuccessful]);
+
+  const onSubmit = (value: LoginSchemaType) => {
+    const registerData = {
+      email: value.email,
+      password: value.password,
     };
-    console.log(loginData);
 
-    isIdValid && isPasswordValid && loginMutate(loginData);
+    loginMutate(registerData);
   };
 
   return (
     <Wrapper>
-      <ValidatedInput
-        placeholder="아이디"
-        onChangeValue={handleIdChange}
-        helperText={idHelperText}
-        nextRef={passwordRef}
-      />
-      <ValidatedInput
-        ref={passwordRef}
-        type="password"
-        placeholder="비밀번호"
-        onChangeValue={handlePasswordChange}
-        helperText={passwordHelperText}
-        nextRef={buttonRef}
-      />
-      <Button
-        ref={buttonRef}
-        size="l"
-        backgroundColor={isLoading ? 'black' : 'orange'}
-        onClick={handleSubmit}
-        disabled={!isIdValid || !isPasswordValid}
-      >
-        로그인
-      </Button>
+      <Form onSubmit={handleSubmit(onSubmit)}>
+        <ValidatedInput
+          {...register('email')}
+          placeholder="아이디"
+          helperText={errorItem.errors.email?.message}
+          // nextRef={passwordReff}
+          // onChangeValue={handleIdChange}
+        />
+        <ValidatedInput
+          {...register('password')}
+          // ref={passwordReff}
+          type="password"
+          placeholder="비밀번호"
+          helperText={errorItem.errors.password?.message}
+          // nextRef={buttonReff}
+          // onChangeValue={handlePasswordChange}
+        />
+        <Button
+          type="submit"
+          // ref={buttonReff}
+          size="l"
+          backgroundColor={state.isSubmitting ? 'black' : 'orange'}
+        >
+          로그인
+        </Button>
+      </Form>
     </Wrapper>
   );
 };
@@ -75,5 +64,12 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 16px;
+`;
+
+const Form = styled.form`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
   gap: 16px;
 `;

--- a/fe/src/components/login/Login.tsx
+++ b/fe/src/components/login/Login.tsx
@@ -19,13 +19,31 @@ export const Login: React.FC = () => {
     }
   }, [state.isSubmitSuccessful]);
 
+  const setErrorAction = (field: keyof LoginSchemaType, message: string) => {
+    errorItem.setError(field, { message }, { shouldFocus: true });
+  };
+
   const onSubmit = (value: LoginSchemaType) => {
     const registerData = {
       email: value.email,
       password: value.password,
     };
 
-    loginMutate(registerData);
+    loginMutate(registerData, {
+      onError: (error) => {
+        switch (error.response?.data.code) {
+          case 'm001':
+            setErrorAction('email', error.response?.data.message);
+            break;
+          case 'a005':
+            setErrorAction('password', error.response?.data.message);
+            break;
+          default:
+            // TODO 추가처리
+            break;
+        }
+      },
+    });
   };
 
   return (

--- a/fe/src/components/login/Login.tsx
+++ b/fe/src/components/login/Login.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useLogin } from 'service/queries/auth';
 import { styled } from 'styled-components';
 import { Button } from 'components/common/button/Button';
@@ -8,8 +8,8 @@ import { LoginSchemaType } from 'hooks/useLoginForm/useLoginFormSchema';
 
 export const Login: React.FC = () => {
   const { mutate: loginMutate } = useLogin();
-  const passwordReff = useRef<HTMLInputElement>(null);
-  const buttonReff = useRef<HTMLButtonElement>(null);
+  // const passwordReff = useRef<HTMLInputElement>(null);
+  // const buttonReff = useRef<HTMLButtonElement>(null);
 
   const { register, handleSubmit, state, errorItem, reset } = useLoginForm();
 

--- a/fe/src/components/login/LoginForm.tsx
+++ b/fe/src/components/login/LoginForm.tsx
@@ -6,7 +6,7 @@ import { ValidatedInput } from 'components/validatedInput/ValidatedInput';
 import { useLoginForm } from 'hooks/useLoginForm/useLoginForm';
 import { LoginSchemaType } from 'hooks/useLoginForm/useLoginFormSchema';
 
-export const Login: React.FC = () => {
+export const LoginForm: React.FC = () => {
   const { mutate: loginMutate } = useLogin();
   // const passwordReff = useRef<HTMLInputElement>(null);
   // const buttonReff = useRef<HTMLButtonElement>(null);

--- a/fe/src/components/register/Register.tsx
+++ b/fe/src/components/register/Register.tsx
@@ -19,6 +19,10 @@ export const Register: React.FC = () => {
     !state.isDirty ||
     !state.isValid;
 
+  const setErrorAction = (field: keyof RegisterSchemaType, message: string) => {
+    errorItem.setError(field, { message }, { shouldFocus: true });
+  };
+
   const onSubmit = async (value: RegisterSchemaType) => {
     const registerData = {
       email: value.email,
@@ -30,35 +34,19 @@ export const Register: React.FC = () => {
 
     resisterMutate(registerData, {
       onError: (error) => {
-        if (error.response?.data.code === 'm003') {
-          errorItem.setError(
-            'nickname',
-            {
-              type: 'duplicate',
-              message: error.response?.data.message,
-            },
-            { shouldFocus: true }
-          );
-        }
-        if (error.response?.data.code === 'm002') {
-          errorItem.setError(
-            'email',
-            {
-              type: 'duplicate',
-              message: error.response?.data.message,
-            },
-            { shouldFocus: true }
-          );
-        }
-        if (error.response?.data.code === 'm004') {
-          errorItem.setError(
-            'reconfirmPassword',
-            {
-              type: 'validate',
-              message: error.response?.data.message,
-            },
-            { shouldFocus: true }
-          );
+        switch (error.response?.data.code) {
+          case 'm002':
+            setErrorAction('email', error.response?.data.message);
+            break;
+          case 'm003':
+            setErrorAction('nickname', error.response?.data.message);
+            break;
+          case 'm004':
+            setErrorAction('reconfirmPassword', error.response?.data.message);
+            break;
+          default:
+            // TODO 추가처리
+            break;
         }
       },
     });

--- a/fe/src/components/register/RegisterForm.tsx
+++ b/fe/src/components/register/RegisterForm.tsx
@@ -8,7 +8,7 @@ import { RegisterSchemaType } from 'hooks/useRegisterForm/useRegisterFormSchema'
 import { Button } from '../common/button/Button';
 import { ArrowDownIcon } from '../common/icon/icons';
 
-export const Register: React.FC = () => {
+export const RegisterForm: React.FC = () => {
   const { register, handleSubmit, state, errorItem } = useRegisterForm();
   const { mutate: resisterMutate } = useRegister();
   const { data: tastes } = useGetTasteMood();

--- a/fe/src/components/validatedInput/ValidatedInput.tsx
+++ b/fe/src/components/validatedInput/ValidatedInput.tsx
@@ -44,11 +44,11 @@ export const ValidatedInput = forwardRef<HTMLInputElement, Props>(
     return (
       <Wrapper>
         <Input variant={variant} isFocused={isFocused} helperText={helperText}>
-          {/* {placeholder && ( */}
-          <Input.InnerLabel isFocused={isFocused}>
-            {placeholder}
-          </Input.InnerLabel>
-          {/* )} */}
+          {placeholder && (
+            <Input.InnerLabel isFocused={isFocused}>
+              {placeholder}
+            </Input.InnerLabel>
+          )}
           <Input.CenterContent>
             <InputField
               ref={ref}

--- a/fe/src/components/validatedInput/ValidatedInput.tsx
+++ b/fe/src/components/validatedInput/ValidatedInput.tsx
@@ -44,9 +44,11 @@ export const ValidatedInput = forwardRef<HTMLInputElement, Props>(
     return (
       <Wrapper>
         <Input variant={variant} isFocused={isFocused} helperText={helperText}>
+          {/* {placeholder && ( */}
           <Input.InnerLabel isFocused={isFocused}>
             {placeholder}
           </Input.InnerLabel>
+          {/* )} */}
           <Input.CenterContent>
             <InputField
               ref={ref}

--- a/fe/src/hooks/useLoginForm/useLoginForm.ts
+++ b/fe/src/hooks/useLoginForm/useLoginForm.ts
@@ -1,0 +1,42 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { LoginSchemaType, loginSchema } from './useLoginFormSchema';
+
+export const useLoginForm = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: {
+      errors,
+      isSubmitting,
+      isSubmitSuccessful,
+      isValidating,
+      isValid,
+      isDirty,
+    },
+    setError,
+    reset,
+  } = useForm<LoginSchemaType>({
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+    mode: 'all',
+    reValidateMode: 'onChange',
+    resolver: zodResolver(loginSchema),
+  });
+
+  return {
+    register,
+    handleSubmit,
+    state: {
+      isSubmitting,
+      isSubmitSuccessful,
+      isValidating,
+      isValid,
+      isDirty,
+    },
+    errorItem: { errors, setError },
+    reset,
+  };
+};

--- a/fe/src/hooks/useLoginForm/useLoginFormSchema.ts
+++ b/fe/src/hooks/useLoginForm/useLoginFormSchema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export type LoginSchemaType = z.infer<typeof loginSchema>;
+
+const emailSchema = () => {
+  return z
+    .string()
+    .min(1, '이메일을 입력해주세요.')
+    .regex(
+      /^[a-zA-Z0-9._-]+@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,6}$/,
+      '이메일 형식에 맞게 입력해주세요.'
+    );
+};
+
+const passwordSchema = () => {
+  return z
+    .string()
+    .min(8, '영문+숫자+특수문자(! @ # $ % & * ?) 조합 8~15자리를 입력해주세요.')
+    .regex(
+      /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/,
+      '영문+숫자+특수문자(! @ # $ % & * ?) 조합 8~15자리를 입력해주세요.'
+    );
+};
+
+export const loginSchema = z.object({
+  email: emailSchema(),
+  password: passwordSchema(),
+});

--- a/fe/src/hooks/usePasswordEditForm/usePasswordEditForm.ts
+++ b/fe/src/hooks/usePasswordEditForm/usePasswordEditForm.ts
@@ -1,0 +1,44 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import {
+  PasswordEditSchemaType,
+  passwordEditSchema,
+} from './usePasswordEditSchema';
+
+export const usePasswordEditForm = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: {
+      errors,
+      isSubmitting,
+      isSubmitSuccessful,
+      isValidating,
+      isValid,
+      isDirty,
+    },
+    setError,
+  } = useForm<PasswordEditSchemaType>({
+    defaultValues: {
+      password: '',
+      newPassword: '',
+      newPasswordCheck: '',
+    },
+    mode: 'all',
+    reValidateMode: 'onChange',
+    resolver: zodResolver(passwordEditSchema),
+  });
+
+  return {
+    register,
+    handleSubmit,
+    state: {
+      isSubmitting,
+      isSubmitSuccessful,
+      isValidating,
+      isValid,
+      isDirty,
+    },
+    errorItem: { errors, setError },
+  };
+};

--- a/fe/src/hooks/usePasswordEditForm/usePasswordEditSchema.ts
+++ b/fe/src/hooks/usePasswordEditForm/usePasswordEditSchema.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export type PasswordEditSchemaType = z.infer<typeof passwordEditSchema>;
+
+const passwordLengthSchema = () => {
+  return z.string().min(8, '비밀번호를 입력해주세요.');
+};
+
+const newPasswordSchema = () => {
+  return z
+    .string()
+    .min(8, '영문+숫자+특수문자(! @ # $ % & * ?) 조합 8~15자리를 입력해주세요.')
+    .regex(
+      /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/,
+      '영문+숫자+특수문자(! @ # $ % & * ?) 조합 8~15자리를 입력해주세요.'
+    );
+};
+
+export const passwordEditSchema = z
+  .object({
+    password: passwordLengthSchema(),
+    newPassword: newPasswordSchema(),
+    newPasswordCheck: passwordLengthSchema(),
+  })
+  .refine((value) => value.password !== value.newPassword, {
+    path: ['newPassword'],
+    message: '기존 비밀번호와 동일합니다.',
+  })
+  .refine((value) => value.newPassword === value.newPasswordCheck, {
+    path: ['newPasswordCheck'],
+    message: '비밀번호가 일치하지 않습니다.',
+  });

--- a/fe/src/hooks/useProfileEditForm/usePofileEditForm.ts
+++ b/fe/src/hooks/useProfileEditForm/usePofileEditForm.ts
@@ -1,0 +1,40 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import {
+  ProfileEditSchemaType,
+  profileEditSchema,
+} from './useProfileEditSchema';
+
+export const useProfileEditForm = (profile?: ProfileMemberInfo) => {
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    getValues,
+    watch,
+    trigger,
+    formState: { errors, isSubmitting },
+    clearErrors,
+    setError,
+  } = useForm<ProfileEditSchemaType>({
+    defaultValues: {
+      nickname: profile?.nickname,
+    },
+    mode: 'onChange',
+    reValidateMode: 'onChange',
+    resolver: zodResolver(profileEditSchema),
+  });
+
+  return {
+    register,
+    handleSubmit,
+    setValue,
+    getValues,
+    watch,
+    trigger,
+    errors,
+    isSubmitting,
+    clearErrors,
+    setError,
+  };
+};

--- a/fe/src/hooks/useProfileEditForm/usePofileEditForm.ts
+++ b/fe/src/hooks/useProfileEditForm/usePofileEditForm.ts
@@ -13,7 +13,7 @@ export const useProfileEditForm = (profile?: ProfileMemberInfo) => {
     getValues,
     watch,
     trigger,
-    formState: { errors, isSubmitting },
+    formState: { errors, isSubmitting, isValidating },
     clearErrors,
     setError,
   } = useForm<ProfileEditSchemaType>({
@@ -34,6 +34,7 @@ export const useProfileEditForm = (profile?: ProfileMemberInfo) => {
     trigger,
     errors,
     isSubmitting,
+    isValidating,
     clearErrors,
     setError,
   };

--- a/fe/src/hooks/useProfileEditForm/usePofileEditForm.ts
+++ b/fe/src/hooks/useProfileEditForm/usePofileEditForm.ts
@@ -18,16 +18,15 @@ export const useProfileEditForm = (profile?: ProfileMemberInfo) => {
       isDirty,
     },
     setError,
-    trigger,
-    watch,
+    clearErrors,
+    getValues,
   } = useForm<ProfileEditSchemaType>({
     defaultValues: {
       nickname: profile?.nickname,
       tasteMoodId: profile?.tasteMoodId,
-      // profileImageId: profile?.profileImageId,
     },
-    mode: 'onSubmit',
-    reValidateMode: 'onSubmit',
+    mode: 'onChange',
+    reValidateMode: 'onChange',
     resolver: zodResolver(profileEditSchema),
   });
 
@@ -41,8 +40,7 @@ export const useProfileEditForm = (profile?: ProfileMemberInfo) => {
       isValid,
       isDirty,
     },
-    errorItem: { errors, setError },
-    trigger,
-    watch,
+    errorItem: { errors, setError, clearErrors },
+    getValues,
   };
 };

--- a/fe/src/hooks/useProfileEditForm/usePofileEditForm.ts
+++ b/fe/src/hooks/useProfileEditForm/usePofileEditForm.ts
@@ -9,33 +9,40 @@ export const useProfileEditForm = (profile?: ProfileMemberInfo) => {
   const {
     register,
     handleSubmit,
-    setValue,
-    getValues,
-    watch,
-    trigger,
-    formState: { errors, isSubmitting, isValidating },
-    clearErrors,
+    formState: {
+      errors,
+      isSubmitting,
+      isSubmitSuccessful,
+      isValidating,
+      isValid,
+      isDirty,
+    },
     setError,
+    trigger,
+    watch,
   } = useForm<ProfileEditSchemaType>({
     defaultValues: {
       nickname: profile?.nickname,
+      tasteMoodId: profile?.tasteMoodId,
+      // profileImageId: profile?.profileImageId,
     },
-    mode: 'onChange',
-    reValidateMode: 'onChange',
+    mode: 'onSubmit',
+    reValidateMode: 'onSubmit',
     resolver: zodResolver(profileEditSchema),
   });
 
   return {
     register,
     handleSubmit,
-    setValue,
-    getValues,
-    watch,
+    state: {
+      isSubmitting,
+      isSubmitSuccessful,
+      isValidating,
+      isValid,
+      isDirty,
+    },
+    errorItem: { errors, setError },
     trigger,
-    errors,
-    isSubmitting,
-    isValidating,
-    clearErrors,
-    setError,
+    watch,
   };
 };

--- a/fe/src/hooks/useProfileEditForm/useProfileEditSchema.ts
+++ b/fe/src/hooks/useProfileEditForm/useProfileEditSchema.ts
@@ -5,26 +5,35 @@ export type ProfileEditSchemaType = z.infer<typeof profileEditSchema>;
 // infer: zod 스키마의 타입을 추론하기 위해 해당 스키마가 어떤 타입을 정의 하는지를 typescript에 알려주는 기능
 
 const nickNameSchema = () => {
-  return z.string().min(2, '닉네임 2자 이상 입력해주세요');
+  return z
+    .string()
+    .min(2, '닉네임은 2~10자 사이로 입력해주세요.')
+    .max(10, '닉네임은 2~10자 사이로 입력해주세요.');
 };
 
 const nickNameDuplicateCheck = async (nickname: string) => {
   const response = await getNicknameDuplicate(nickname);
+
   return !response.isDuplicate;
 };
 
-// const tasteMoodIdSchema = () => {
-//   return z.string();
-// }
+const tasteMoodSchema = () => {
+  return z.string().min(1, '맛과 분위기를 선택해주세요.');
+};
+
+// const profileImageSchema = () => {
+//   return z.string().nullable().optional();
+// };
 
 export const profileEditSchema = z
   .object({
     nickname: nickNameSchema(),
-    // tasteMoodId:
+    tasteMoodId: tasteMoodSchema(),
+    // profileImageId: profileImageSchema(),
   })
   .refine(
     async (value) => {
-      nickNameDuplicateCheck(value.nickname);
+      return await nickNameDuplicateCheck(value.nickname);
     },
     {
       path: ['nickname'],
@@ -32,19 +41,19 @@ export const profileEditSchema = z
     }
   );
 
-// .refine((data) => data.password === data.passwordCheck, {
-//   path: ['passwordCheck'],
-//   message: '비밀번호가 일치하지 않습니다.',
-// })
+// const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 2;
+// const ALLOWED_TYPES = ['image/png', 'image/jpg', 'image/jpeg'];
 
-// .object({
-//   nickname: z.string().min(2, '닉네임을 입력해주세요'),
-//   password: z
-//     .string()
-//     .min(8, '비밀번호를 입력해주세요.')
-//     .regex(
-//       /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/,
-//       '영문+숫자+특수문자(! @ # $ % & * ?) 조합 8~15자리를 입력해주세요.'
+// const RegistrationSchema = z.object({
+//   profileImage: z
+//     .any()
+//     .refine((files) => files?.length === 1, 'Image is required.')
+//     .refine(
+//       (files) => files?.[0]?.size <= MAX_FILE_SIZE_BYTES,
+//       '이미지는 2MB 이하의 png, jpg, jpeg 파일만 업로드 가능합니다.'
+//     )
+//     .refine(
+//       (files) => ALLOWED_TYPES.includes(files?.[0]?.type),
+//       '이미지는 2MB 이하의 png, jpg, jpeg 파일만 업로드 가능합니다.'
 //     ),
-//   passwordCheck: z.string().min(8, '비밀번호를 입력해주세요.'),
-// })
+// });

--- a/fe/src/hooks/useProfileEditForm/useProfileEditSchema.ts
+++ b/fe/src/hooks/useProfileEditForm/useProfileEditSchema.ts
@@ -1,4 +1,3 @@
-import { getNicknameDuplicate } from 'service/axios/profile/profile';
 import { z } from 'zod';
 
 export type ProfileEditSchemaType = z.infer<typeof profileEditSchema>;
@@ -11,12 +10,6 @@ const nickNameSchema = () => {
     .max(10, '닉네임은 2~10자 사이로 입력해주세요.');
 };
 
-const nickNameDuplicateCheck = async (nickname: string) => {
-  const response = await getNicknameDuplicate(nickname);
-
-  return !response.isDuplicate;
-};
-
 const tasteMoodSchema = () => {
   return z.string().min(1, '맛과 분위기를 선택해주세요.');
 };
@@ -25,21 +18,11 @@ const tasteMoodSchema = () => {
 //   return z.string().nullable().optional();
 // };
 
-export const profileEditSchema = z
-  .object({
-    nickname: nickNameSchema(),
-    tasteMoodId: tasteMoodSchema(),
-    // profileImageId: profileImageSchema(),
-  })
-  .refine(
-    async (value) => {
-      return await nickNameDuplicateCheck(value.nickname);
-    },
-    {
-      path: ['nickname'],
-      message: '중복된 닉네임입니다.',
-    }
-  );
+export const profileEditSchema = z.object({
+  nickname: nickNameSchema(),
+  tasteMoodId: tasteMoodSchema(),
+  // profileImageId: profileImageSchema(),
+});
 
 // const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 2;
 // const ALLOWED_TYPES = ['image/png', 'image/jpg', 'image/jpeg'];

--- a/fe/src/hooks/useProfileEditForm/useProfileEditSchema.ts
+++ b/fe/src/hooks/useProfileEditForm/useProfileEditSchema.ts
@@ -1,0 +1,42 @@
+import { getNicknameDuplicate } from 'service/axios/profile/profile';
+import { z } from 'zod';
+
+export type ProfileEditSchemaType = z.infer<typeof profileEditSchema>;
+// infer: zod 스키마의 타입을 추론하기 위해 해당 스키마가 어떤 타입을 정의 하는지를 typescript에 알려주는 기능
+
+const nickNameSchema = () => {
+  return z.string().min(2, '닉네임 2자 이상 입력해주세요');
+};
+
+export const profileEditSchema = z
+  .object({
+    nickname: nickNameSchema(),
+  })
+  .refine(
+    async (value) => {
+      const response = await getNicknameDuplicate(value.nickname); // 여기를 리액트 쿼리를 쓸 순없나?
+      console.log(response, 'response');
+      return !response.isDuplicate;
+    },
+    {
+      path: ['nickname'],
+      message: '중복된 닉네임입니다.',
+    }
+  );
+
+// .refine((data) => data.password === data.passwordCheck, {
+//   path: ['passwordCheck'],
+//   message: '비밀번호가 일치하지 않습니다.',
+// })
+
+// .object({
+//   nickname: z.string().min(2, '닉네임을 입력해주세요'),
+//   password: z
+//     .string()
+//     .min(8, '비밀번호를 입력해주세요.')
+//     .regex(
+//       /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/,
+//       '영문+숫자+특수문자(! @ # $ % & * ?) 조합 8~15자리를 입력해주세요.'
+//     ),
+//   passwordCheck: z.string().min(8, '비밀번호를 입력해주세요.'),
+// })

--- a/fe/src/hooks/useProfileEditForm/useProfileEditSchema.ts
+++ b/fe/src/hooks/useProfileEditForm/useProfileEditSchema.ts
@@ -8,15 +8,23 @@ const nickNameSchema = () => {
   return z.string().min(2, '닉네임 2자 이상 입력해주세요');
 };
 
+const nickNameDuplicateCheck = async (nickname: string) => {
+  const response = await getNicknameDuplicate(nickname);
+  return !response.isDuplicate;
+};
+
+// const tasteMoodIdSchema = () => {
+//   return z.string();
+// }
+
 export const profileEditSchema = z
   .object({
     nickname: nickNameSchema(),
+    // tasteMoodId:
   })
   .refine(
     async (value) => {
-      const response = await getNicknameDuplicate(value.nickname); // 여기를 리액트 쿼리를 쓸 순없나?
-      console.log(response, 'response');
-      return !response.isDuplicate;
+      nickNameDuplicateCheck(value.nickname);
     },
     {
       path: ['nickname'],

--- a/fe/src/hooks/useRegisterForm/useRegisterForm.ts
+++ b/fe/src/hooks/useRegisterForm/useRegisterForm.ts
@@ -1,0 +1,46 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { RegisterSchemaType, registerSchema } from './useRegisterFormSchema';
+
+export const useRegisterForm = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: {
+      errors,
+      isSubmitting,
+      isSubmitSuccessful,
+      isValidating,
+      isValid,
+      isDirty,
+    },
+    setError,
+    clearErrors,
+    getValues,
+  } = useForm<RegisterSchemaType>({
+    defaultValues: {
+      email: '',
+      nickname: '',
+      password: '',
+      reconfirmPassword: '',
+      tasteMoodId: '',
+    },
+    mode: 'onChange',
+    reValidateMode: 'onChange',
+    resolver: zodResolver(registerSchema),
+  });
+
+  return {
+    register,
+    handleSubmit,
+    state: {
+      isSubmitting,
+      isSubmitSuccessful,
+      isValidating,
+      isValid,
+      isDirty,
+    },
+    errorItem: { errors, setError, clearErrors },
+    getValues,
+  };
+};

--- a/fe/src/hooks/useRegisterForm/useRegisterFormSchema.ts
+++ b/fe/src/hooks/useRegisterForm/useRegisterFormSchema.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+export type RegisterSchemaType = z.infer<typeof registerSchema>;
+
+const emailSchema = () => {
+  return z
+    .string()
+    .min(1, '이메일을 입력해주세요.')
+    .regex(
+      /^[a-zA-Z0-9._-]+@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,6}$/,
+      '이메일 형식에 맞게 입력해주세요.'
+    );
+};
+
+const nickNameSchema = () => {
+  return z
+    .string()
+    .min(2, '닉네임은 2~10자 사이로 입력해주세요.')
+    .max(10, '닉네임은 2~10자 사이로 입력해주세요.');
+};
+
+const passwordLengthSchema = () => {
+  return z.string().min(8, '비밀번호를 입력해주세요.');
+};
+
+const passwordSchema = () => {
+  return z
+    .string()
+    .min(8, '영문+숫자+특수문자(! @ # $ % & * ?) 조합 8~15자리를 입력해주세요.')
+    .regex(
+      /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,15}$/,
+      '영문+숫자+특수문자(! @ # $ % & * ?) 조합 8~15자리를 입력해주세요.'
+    );
+};
+
+const tasteMoodSchema = () => {
+  return z.string().min(1, '맛과 분위기를 선택해주세요.');
+};
+
+export const registerSchema = z
+  .object({
+    email: emailSchema(),
+    nickname: nickNameSchema(),
+    password: passwordSchema(),
+    reconfirmPassword: passwordLengthSchema(),
+    tasteMoodId: tasteMoodSchema(),
+  })
+  .refine((value) => value.password === value.reconfirmPassword, {
+    path: ['reconfirmPassword'],
+    message: '비밀번호가 일치하지 않습니다.',
+  });

--- a/fe/src/pages/AcountPage.tsx
+++ b/fe/src/pages/AcountPage.tsx
@@ -1,3 +1,4 @@
+import { useDeleteAccount } from 'service/queries/account';
 import 'service/queries/profile';
 import { styled } from 'styled-components';
 import { Button } from 'components/common/button/Button';
@@ -6,17 +7,19 @@ import {
   FlexRowBox,
 } from 'components/common/feedUserInfo/FeedUserInfo';
 import { useModal } from 'components/common/modal/useModal';
+import { useAuthState } from 'hooks/auth/useAuth';
 // import { Spinner } from 'components/common/loading/spinner';
 
 import { usePageNavigator } from 'hooks/usePageNavigator';
 
 export const AccountPage = () => {
   const { navigateToPassword } = usePageNavigator();
-
+  const { userInfo } = useAuthState();
+  const { mutate: accountMutate } = useDeleteAccount(userInfo.id);
   const { openModal, closeModal } = useModal<'accountAlert'>();
 
   const handleDelete = () => {
-    //deletemutate
+    accountMutate();
   };
 
   const handleAlert = () => {

--- a/fe/src/pages/LoginPage.tsx
+++ b/fe/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components';
 import { TextButton } from 'components/common/button/TextButton';
 import { LogoXLarge } from 'components/common/icon/icons';
-import { Login } from 'components/login/Login';
+import { LoginForm } from 'components/login/LoginForm';
 import { usePageNavigator } from 'hooks/usePageNavigator';
 
 export const LoginPage = () => {
@@ -13,7 +13,7 @@ export const LoginPage = () => {
         <Header>
           <LogoXLarge onClick={navigateToHome} />
         </Header>
-        <Login />
+        <LoginForm />
         <ButtonWrapper>
           <span>계정이 없으신가요?</span>
           <TextButton color="orange" size="m" onClick={navigateToRegister}>

--- a/fe/src/pages/PasswordPage.tsx
+++ b/fe/src/pages/PasswordPage.tsx
@@ -32,7 +32,6 @@ export const PasswordPage = () => {
           errorItem.setError(
             'password',
             {
-              type: 'validate',
               message: error.response?.data.message,
             },
             { shouldFocus: true }

--- a/fe/src/pages/ProfileEditPage.tsx
+++ b/fe/src/pages/ProfileEditPage.tsx
@@ -41,9 +41,9 @@ export const ProfileEditPage = () => {
   const handleDuplicateCheck = async () => {
     const nickname = getValues('nickname');
     const res = await getNicknameDuplicate(nickname);
+
     if (res.isDuplicate) {
       errorItem.setError('nickname', {
-        type: 'duplicate',
         message: '이미 존재하는 닉네임입니다.',
       });
     } else {
@@ -65,7 +65,6 @@ export const ProfileEditPage = () => {
           errorItem.setError(
             'nickname',
             {
-              type: 'duplicate',
               message: error.response?.data.message,
             },
             { shouldFocus: true }

--- a/fe/src/pages/ProfileEditPage.tsx
+++ b/fe/src/pages/ProfileEditPage.tsx
@@ -1,11 +1,6 @@
-import { get } from 'firebase/database';
 import { getNicknameDuplicate } from 'service/axios/profile/profile';
 import { useGetTasteMood } from 'service/queries/mood';
-import {
-  useEditProfile,
-  useGetNicknameDuplicate,
-  useGetProfile,
-} from 'service/queries/profile';
+import { useEditProfile, useGetProfile } from 'service/queries/profile';
 import { styled } from 'styled-components';
 import { Button } from 'components/common/button/Button';
 import {

--- a/fe/src/pages/ProfileEditPage.tsx
+++ b/fe/src/pages/ProfileEditPage.tsx
@@ -43,50 +43,18 @@ export const ProfileEditPage = () => {
     watch,
     trigger,
     errors,
+    isValidating,
     isSubmitting,
     clearErrors,
     setError,
   } = useProfileEditForm(profile);
 
-  const {
-    data: checkedNickname,
-    isFetching: isDuplicateFetching,
-    refetch: duplicateCheck,
-  } = useGetNicknameDuplicate(watch('nickname'));
-
   const { data: tastes } = useGetTasteMood();
   const { mutate: profileMutate } = useEditProfile(userInfo.id);
   const isAuthor = profile?.id === userInfo.id;
 
-  // const {
-  //   value: nicknameValue,
-  //   handleChange: handleNicknameChange,
-  //   helperText: nicknameHelperText,
-  //   isValid: isNicknameValid,
-  // } = useInput({
-  //   initialValue: '',
-  //   validator: (value) => value.length >= 2,
-  //   // nickname이 중복일때도 검증해야함
-  //   helperText: '닉네임은 2자 이상 입력해주세요',
-  // });
   console.log(errors, 'errors');
-
-  console.log(watch('nickname').length);
-
-  // const handleSubmit = () => {
-  //   const registerData = {
-  //     nickname: nicknameValue,
-  //     tasteMoodId: selectedTaste?.id,
-  //     profileImageId: '1', // 여기
-  //   };
-  //   console.log(registerData);
-
-  //   //mutate
-  // };
-
-  const handleDuplicateCheck = () => {
-    duplicateCheck();
-  };
+  console.log(errors.nickname?.message, 'errors message');
 
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedName = e.target.value;
@@ -100,7 +68,7 @@ export const ProfileEditPage = () => {
   // const isFormValid = isNicknameValid && selectedTaste.id !== '';
 
   const onSubmit = async (data: ProfileEditSchemaType) => {
-    console.log(data);
+    console.log(data, 'submitiiiiing');
 
     // const editedProfileBody = {
     //   nickname: data.nickname === profile?.nickname ? null : data.nickname,
@@ -146,10 +114,10 @@ export const ProfileEditPage = () => {
                     // async필요없나?
                     trigger('nickname');
                   }}
-                  disabled={isSubmitting || watch('nickname').length < 2}
+                  disabled={isValidating || watch('nickname').length < 2}
                 >
                   중복검사
-                  <Spinner isLoading={isDuplicateFetching} color="black" />
+                  <Spinner isLoading={isValidating} color="black" />
                 </Button>
               </Row>
             </SectionRow>

--- a/fe/src/pages/RegisterPage.tsx
+++ b/fe/src/pages/RegisterPage.tsx
@@ -1,7 +1,7 @@
 import { styled } from 'styled-components';
 import { TextButton } from 'components/common/button/TextButton';
 import { LogoXLarge } from 'components/common/icon/icons';
-import { Register } from 'components/register/Register';
+import { RegisterForm } from 'components/register/RegisterForm';
 import { usePageNavigator } from 'hooks/usePageNavigator';
 
 export const RegisterPage = () => {
@@ -12,9 +12,7 @@ export const RegisterPage = () => {
         <Header>
           <LogoXLarge onClick={navigateToHome} />
         </Header>
-
-        <Register />
-
+        <RegisterForm />
         <ButtonWrapper>
           <span>계정이 있으신가요?</span>
           <TextButton color="orange" size="m" onClick={navigateToLogin}>

--- a/fe/src/service/axios/account/account.ts
+++ b/fe/src/service/axios/account/account.ts
@@ -1,0 +1,12 @@
+import { privateApi } from 'service/axios/fetcher';
+import { END_POINT } from 'service/constants/endpoint';
+
+export const putEditPassword = async (memberId: string, body: PasswordBody) => {
+  const { data } = await privateApi.put(END_POINT.password(memberId), body);
+  return data;
+};
+
+export const deleteAccount = async (memberId?: string) => {
+  const { data } = await privateApi.delete(END_POINT.member(memberId));
+  return data;
+};

--- a/fe/src/service/axios/profile/profile.ts
+++ b/fe/src/service/axios/profile/profile.ts
@@ -19,3 +19,11 @@ export const getNicknameDuplicate = async (nickname: string) => {
   const { data } = await privateApi.get(END_POINT.nickName(encodedNickname));
   return data;
 };
+
+export const patchEditProfile = async (
+  memberId: string,
+  body: ProfileEditBody
+) => {
+  const { data } = await privateApi.patch(END_POINT.member(memberId), body);
+  return data;
+};

--- a/fe/src/service/constants/endpoint.ts
+++ b/fe/src/service/constants/endpoint.ts
@@ -9,6 +9,7 @@ export const END_POINT = {
   replyLike: ({ commentId, replyId }: ReplyLike) =>
     `comments/${commentId}/replies/${replyId}/likes`,
   member: (id?: string) => (id ? `/members/${id}` : `/members`),
+  password: (id?: string) => `/members/${id}/password`,
   feed: (id?: string) => (id ? `/feeds/${id}` : `/feeds`),
   comment: (id?: string) => (id ? `/comments/${id}` : `/comments`),
   reply: (id: string) => `/comments/${id}/replies`,

--- a/fe/src/service/queries/account.ts
+++ b/fe/src/service/queries/account.ts
@@ -1,0 +1,44 @@
+import { useMutation } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
+import { useToast } from 'recoil/toast/useToast';
+import { deleteAccount, putEditPassword } from 'service/axios/account/account';
+import { clearLoginInfo } from 'utils/localStorage';
+import { PATH } from 'constants/path';
+
+export const usePutPassword = (id: string) => {
+  const toast = useToast();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (body: PasswordBody) => putEditPassword(id, body),
+    onSuccess: () => {
+      toast.success('비밀번호를 변경했습니다.');
+      navigate(PATH.SETTING);
+    },
+    onError: (error: AxiosError<CustomErrorResponse>) => {
+      const errorData = error?.response?.data;
+
+      errorData && toast.error(errorData.message);
+    },
+  });
+};
+
+export const useDeleteAccount = (id: string) => {
+  const toast = useToast();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: () => deleteAccount(id),
+    onSuccess: () => {
+      toast.success('성공적으로 탈퇴 되었습니다.');
+      clearLoginInfo();
+      navigate(PATH.HOME, { replace: true });
+    },
+    onError: (error: AxiosError<CustomErrorResponse>) => {
+      const errorData = error?.response?.data;
+
+      errorData && toast.error(errorData.message);
+    },
+  });
+};

--- a/fe/src/service/queries/auth.ts
+++ b/fe/src/service/queries/auth.ts
@@ -59,8 +59,10 @@ export const useLogout = () => {
       toast.success('로그아웃 되었습니다.');
       navigateToPath(from);
     },
-    onError: (error) => {
-      console.log('Logout error:', error);
+    onError: (error: AxiosError<CustomErrorResponse>) => {
+      const errorData = error?.response?.data;
+
+      errorData && toast.error(errorData.message);
     },
   });
 };
@@ -73,6 +75,7 @@ export const useRegister = () => {
     mutationFn: (body: RegisterBody) => fetchRegister(body),
     onSuccess: () => {
       navigate(PATH.LOGIN, { replace: true });
+      toast.success('회원가입 되었습니다.');
     },
     onError: (error: AxiosError<CustomErrorResponse>) => {
       const errorData = error?.response?.data;

--- a/fe/src/service/queries/profile.ts
+++ b/fe/src/service/queries/profile.ts
@@ -1,18 +1,18 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useToast } from 'recoil/toast/useToast';
 import {
   getNicknameDuplicate,
   getProfile,
+  patchEditProfile,
   patchProfileImage,
 } from 'service/axios/profile/profile';
 import { QUERY_KEY } from 'service/constants/queryKey';
 
 export const useGetProfile = (id?: string) =>
   useQuery<ProfileMemberInfo>({
-    queryKey: [QUERY_KEY.profile],
+    queryKey: [QUERY_KEY.profile, id],
     queryFn: () => getProfile(id),
-    staleTime: Infinity,
   });
 
 export const useEditProfileImage = (id: string) => {
@@ -29,11 +29,30 @@ export const useEditProfileImage = (id: string) => {
   });
 };
 
-// export const useEditProfile = () => {};
+export const useEditProfile = (memberId: string) => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: (body: ProfileEditBody) => patchEditProfile(memberId, body),
+    onSuccess: () => {
+      toast.success('프로필을 수정했습니다.');
+      queryClient.invalidateQueries([QUERY_KEY.profile, memberId]); //디테일 페이지 데이터를 다시 갱신시키고 바뀐 imageId 싱크를 맞추기 위함, 이렇게해서 imageId는 항상 이전값과 같으므로 null로 보낼수있음, 이미지는 에딧 하자마자 뮤테이트 됨.
+
+      // 어디로 이동까지 시켜야할지?
+    },
+    onError: (error: AxiosError<CustomErrorResponse>) => {
+      const errorData = error?.response?.data;
+      console.log('useEditProfile error: ', error);
+
+      errorData && toast.error(errorData.message);
+    },
+  });
+};
 
 export const useGetNicknameDuplicate = (nickName: string) => {
   return useQuery({
-    queryKey: [QUERY_KEY.nickname, nickName], //여기도 닉네임을 넣어줘야하는지?
+    queryKey: [QUERY_KEY.nickname, nickName],
     queryFn: () => getNicknameDuplicate(nickName),
     enabled: false,
   });

--- a/fe/src/service/queries/profile.ts
+++ b/fe/src/service/queries/profile.ts
@@ -9,17 +9,23 @@ import {
 } from 'service/axios/profile/profile';
 import { QUERY_KEY } from 'service/constants/queryKey';
 
-export const useGetProfile = (id?: string) =>
+export const useGetProfile = (memberId?: string) =>
   useQuery<ProfileMemberInfo>({
-    queryKey: [QUERY_KEY.profile, id],
-    queryFn: () => getProfile(id),
+    queryKey: [QUERY_KEY.profile, memberId],
+    queryFn: () => getProfile(memberId),
   });
 
-export const useEditProfileImage = (id: string) => {
+export const useEditProfileImage = (memberId: string) => {
+  const queryClient = useQueryClient();
+
   const toast = useToast();
 
   return useMutation({
-    mutationFn: (body: ProfileImageBody) => patchProfileImage(id, body),
+    mutationFn: (body: ProfileImageBody) => patchProfileImage(memberId, body),
+    onSuccess: () => {
+      toast.success('프로필 이미지를 수정했습니다.');
+      queryClient.invalidateQueries([QUERY_KEY.profile, memberId]);
+    },
     onError: (error: AxiosError<CustomErrorResponse>) => {
       const errorData = error?.response?.data;
       console.log('useEditProfileImage error: ', error);
@@ -37,7 +43,7 @@ export const useEditProfile = (memberId: string) => {
     mutationFn: (body: ProfileEditBody) => patchEditProfile(memberId, body),
     onSuccess: () => {
       toast.success('프로필을 수정했습니다.');
-      queryClient.invalidateQueries([QUERY_KEY.profile, memberId]); //디테일 페이지 데이터를 다시 갱신시키고 바뀐 imageId 싱크를 맞추기 위함, 이렇게해서 imageId는 항상 이전값과 같으므로 null로 보낼수있음, 이미지는 에딧 하자마자 뮤테이트 됨.
+      queryClient.invalidateQueries([QUERY_KEY.profile, memberId]);
 
       // 어디로 이동까지 시켜야할지?
     },

--- a/fe/src/types/account.d.ts
+++ b/fe/src/types/account.d.ts
@@ -1,0 +1,4 @@
+type PasswordBody = {
+  oldPassword: string;
+  newPassword: string;
+};

--- a/fe/src/types/profile.d.ts
+++ b/fe/src/types/profile.d.ts
@@ -20,4 +20,12 @@ type MyFeeds = {
 type ProfileImageBody = {
   profileImageId: string;
   tasteMoodId: null;
+  nickname: null;
+};
+
+type ProfileEditBody = {
+  // 이전값이랑 비교해서 | null 해도 되는지 보기
+  profileImageId: string | null;
+  tasteMoodId: string | null;
+  nickname: string | null;
 };

--- a/fe/src/utils/generateDefaultUserImage.ts
+++ b/fe/src/utils/generateDefaultUserImage.ts
@@ -1,5 +1,3 @@
 export const generateDefaultUserImage = (userId: string) => {
-  const defaultUserImage = `https://source.boringavatars.com/beam/${userId}`;
-
-  return defaultUserImage;
+  return `https://source.boringavatars.com/beam/${userId}`;
 };


### PR DESCRIPTION
## Key changes🔧
- 폼제어 : react hook form 
- validation : zod
- 프로필수정, 비밀번호수정, 회원탈퇴 연동 
- 로그인, 회원가입 폼 변경
## To reviewer👋
<<로그인>> 엔터만으로만 이동하는거 이제 안돼요
  - 마우스 쓰지마시고 탭으로 이동 + 엔터치세요
  - react-hook-form의 ref방식의(unControlled) 폼을 쓰니 기존에 걸어둔 ref가 있으면 제대로 form제어를 못하더라고요
  - controlled 폼은 ref가 아닌 기존처럼 상태를 두고 쓰는데 로그인폼만 그렇게 만들자니 딱히 그럴 이유가 없는거 같아서 ref방식의 폼으로 작성했습니다 
