### PR TITLE
[FE] 팔로우 언팔로우 연동, 프로필페이지 이동 추가

### DIFF
--- a/fe/src/assets/userChecked.svg
+++ b/fe/src/assets/userChecked.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.0005 5.2C16.7005 6.9 16.7005 9.6 15.0005 11.2C13.3005 12.8 10.6005 12.9 9.00048 11.2C7.40048 9.5 7.30048 6.8 9.00048 5.2C10.7005 3.6 13.3005 3.6 15.0005 5.2" stroke="#0A0A0A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 20C4 17.5 6 15.5 8.5 15.5H11.1" stroke="#0A0A0A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.1476 20.1153L20.8888 16.3741" stroke="#0A0A0A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 18.0205L17 20.0205" stroke="#0A0A0A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/fe/src/components/common/commentItem/CommentItem.tsx
+++ b/fe/src/components/common/commentItem/CommentItem.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useDeleteComment, usePutComment } from 'service/queries/comment';
 import { useDeleteCommentLike, usePostCommentLike } from 'service/queries/like';
 import { styled } from 'styled-components';
@@ -11,6 +12,7 @@ import { Input } from '../input/Input';
 import { InputField } from '../input/InputField';
 import { useModal } from '../modal/useModal';
 import { UserImage } from '../userImage/UserImage';
+import { PATH } from 'constants/path';
 
 type Props = {
   createdAt: string;
@@ -20,6 +22,8 @@ type Props = {
 export const CommentItem: React.FC<Props> = ({ createdAt, comment }) => {
   console.log(comment, ' now commentItems');
   const inputRef = useRef(null);
+  const navigate = useNavigate();
+
   const [isEdit, setIsEdit] = useState(false);
   const { isLogin, userInfo } = useAuthState();
   const { navigateToLogin } = usePageNavigator();
@@ -94,10 +98,17 @@ export const CommentItem: React.FC<Props> = ({ createdAt, comment }) => {
     }
   };
 
+  const handleNavigateProfile = () => {
+    navigate(PATH.PROFILE + '/' + comment.member.id);
+  };
+
   return (
     <Wrapper>
       <ContentLeft>
-        <UserImage imageUrl={comment.member.imageUrl} />
+        <UserImage
+          imageUrl={comment.member.imageUrl}
+          onClick={handleNavigateProfile}
+        />
         <FlexColumnBox>
           <ContentHeader>
             <Nickname>{comment.member.nickname}</Nickname>

--- a/fe/src/components/common/feedUserInfo/FeedUserInfo.tsx
+++ b/fe/src/components/common/feedUserInfo/FeedUserInfo.tsx
@@ -2,7 +2,6 @@ import { useNavigate } from 'react-router-dom';
 import { useDeleteFeed } from 'service/queries/feed';
 import { styled } from 'styled-components';
 import { useAuthState } from 'hooks/auth/useAuth';
-import { usePageNavigator } from 'hooks/usePageNavigator';
 import { formatTimeStamp } from 'utils/formatTimeStamp';
 import { generateDefaultUserImage } from 'utils/generateDefaultUserImage';
 import { Badge } from '../badge/Badge';
@@ -27,11 +26,14 @@ export const FeedUserInfo: React.FC<Props> = ({
   location,
   feedId,
 }) => {
-  const { navigateToProfile } = usePageNavigator();
   const navigate = useNavigate();
   const { mutate: deleteMutate } = useDeleteFeed();
   const { isLogin, userInfo } = useAuthState();
   const formattedTimeStamp = formatTimeStamp(createdAt);
+
+  const handleNavigateProfile = () => {
+    navigate(PATH.PROFILE + '/' + member.id);
+  };
 
   const publicMenu = [
     {
@@ -87,7 +89,7 @@ export const FeedUserInfo: React.FC<Props> = ({
       <ContentLeft>
         <UserImage
           imageUrl={member.imageUrl || generateDefaultUserImage(member.id)}
-          onClick={navigateToProfile}
+          onClick={handleNavigateProfile}
         />
         <FlexColumnBox>
           <ContentHeader>

--- a/fe/src/components/common/feedUserInfo/FeedUserInfo.tsx
+++ b/fe/src/components/common/feedUserInfo/FeedUserInfo.tsx
@@ -49,8 +49,10 @@ export const FeedUserInfo: React.FC<Props> = ({
     {
       id: 3,
       content: '팔로우',
-      onClick: () => {},
-    },
+      onClick: () => {
+        navigate(`${PATH.PROFILE}/${member.id}`);
+      },
+    }, // 일단 프로필로 이동
     {
       id: 4,
       content: '공유하기',

--- a/fe/src/components/common/icon/icons.ts
+++ b/fe/src/components/common/icon/icons.ts
@@ -35,6 +35,7 @@ export { default as ToastErrorIcon } from 'assets/toastError.svg?react';
 export { default as ToastNotiIcon } from 'assets/toastNoti.svg?react';
 export { default as ToastSuccessIcon } from 'assets/toastSuccess.svg?react';
 export { default as UserPlusIcon } from 'assets/userPlus.svg?react';
+export { default as UserCheckedIcon } from 'assets/userChecked.svg?react';
 export { default as SantaHat } from 'assets/santaHat.svg?react';
 export { default as HeartSmallEmpty } from 'assets/heartSmallEmpty.svg?react';
 export { default as HeartSmallFill } from 'assets/heartSmallFill.svg?react';

--- a/fe/src/components/common/userImage/UserImageEdit.tsx
+++ b/fe/src/components/common/userImage/UserImageEdit.tsx
@@ -35,6 +35,10 @@ export const UserImageEdit: React.FC<Props> = ({
   const userImage = imageData.url || defaultImage;
 
   const handleImageClick = () => {
+    if (!isAuthor) {
+      return;
+    }
+
     if (inputRef.current) {
       inputRef.current.click();
     }

--- a/fe/src/components/common/userImage/UserImageEdit.tsx
+++ b/fe/src/components/common/userImage/UserImageEdit.tsx
@@ -66,9 +66,8 @@ export const UserImageEdit: React.FC<Props> = ({
 
     imageMutate(formData, {
       onSuccess: (res) => {
-        console.log(res, ' now res');
         setImageData(res);
-        //여기에 프로필 수정 mutate하기
+
         profileImageMutate({
           nickname: null,
           tasteMoodId: null,
@@ -81,7 +80,6 @@ export const UserImageEdit: React.FC<Props> = ({
       inputRef.current.value = '';
     }
   };
-  // 프로필 전체 수정 mutate가져와서 바뀐 이미지로 제출할수있게 하기
 
   return (
     <Wrapper onClick={handleImageClick}>

--- a/fe/src/components/followButton/FollowButton.tsx
+++ b/fe/src/components/followButton/FollowButton.tsx
@@ -1,0 +1,42 @@
+import { useDeleteFollow, usePostFollow } from 'service/queries/follow';
+import { Button } from 'components/common/button/Button';
+import { UserCheckedIcon, UserPlusIcon } from 'components/common/icon/icons';
+
+// import { Spinner } from 'components/common/loading/spinner';
+
+type Props = {
+  memberId: string;
+  isFollowing: boolean;
+};
+export const FollowButton: React.FC<Props> = ({ memberId, isFollowing }) => {
+  const { mutate: followMutate, isLoading: isFollowLoading } =
+    usePostFollow(memberId);
+  const { mutate: unfollowMutate, isLoading: isUnFlollowLoading } =
+    useDeleteFollow(memberId);
+
+  const handleToggleFollow = () => {
+    isFollowing ? unfollowMutate() : followMutate();
+  };
+
+  return (
+    <>
+      <Button
+        size="s"
+        backgroundColor={
+          isFollowLoading || isUnFlollowLoading ? 'black' : 'white'
+        }
+        width={140}
+        disabled={isFollowLoading || isUnFlollowLoading}
+        onClick={handleToggleFollow}
+      >
+        {(!isFollowLoading || !isUnFlollowLoading) && isFollowing ? (
+          <UserCheckedIcon />
+        ) : (
+          <UserPlusIcon />
+        )}
+        <span>{isFollowing ? '팔로우' : '팔로잉'}</span>
+        {/* <Spinner isLoading={isFollowLoading || isUnFlollowLoading} /> 일부러 시간을 오래잡아서 스피너를 보여줄지? */}
+      </Button>
+    </>
+  );
+};

--- a/fe/src/components/profileUserInfo/ProfileUserInfo.tsx
+++ b/fe/src/components/profileUserInfo/ProfileUserInfo.tsx
@@ -1,11 +1,12 @@
 import { styled } from 'styled-components';
 import { media } from 'styles/mediaQuery';
+import { FollowButton } from 'components/followButton/FollowButton';
 import { useAuthState } from 'hooks/auth/useAuth';
 import { usePageNavigator } from 'hooks/usePageNavigator';
 import { generateDefaultUserImage } from 'utils/generateDefaultUserImage';
 import { Badge } from '../common/badge/Badge';
 import { Button } from '../common/button/Button';
-import { CollectableAddIcon, UserPlusIcon } from '../common/icon/icons';
+import { CollectableAddIcon } from '../common/icon/icons';
 import { UserImageEdit } from '../common/userImage/UserImageEdit';
 
 type Props = {
@@ -27,13 +28,10 @@ export const ProfileUserInfo: React.FC<Props> = ({ member }) => {
     navigateToProfileEdit();
   };
 
-  const handleToggleFollow = () => {};
-
   return (
     <Wrapper>
       <ContentLeft>
         <UserImageEdit
-
           isAuthor={isAuthor}
           imageUrl={
             member.profileImageUrl || generateDefaultUserImage(member.id)
@@ -48,13 +46,16 @@ export const ProfileUserInfo: React.FC<Props> = ({ member }) => {
 
           <ContentBody>
             <InfoItem>
-              {/* {member.myFeedsCount} */}1<span>게시물</span>
+              {member.feedCount}
+              <span>게시물</span>
             </InfoItem>
             <InfoItem>
-              {/* {member.myFeedsCount} */}2<span>팔로잉</span>
+              {member.followingCount}
+              <span>팔로잉</span>
             </InfoItem>
             <InfoItem>
-              {/* {member.myFeedsCount} */}3<span>팔로워</span>
+              {member.followerCount}
+              <span>팔로워</span>
             </InfoItem>
           </ContentBody>
         </Column>
@@ -74,15 +75,7 @@ export const ProfileUserInfo: React.FC<Props> = ({ member }) => {
             <span>프로필 수정</span>
           </Button>
         ) : (
-          <Button
-            size="s"
-            backgroundColor="white"
-            width={140}
-            onClick={handleToggleFollow}
-          >
-            <UserPlusIcon />
-            <span>팔로우</span>
-          </Button>
+          <FollowButton memberId={member.id} isFollowing={member.following} />
         )}
       </ButtonBox>
     </Wrapper>

--- a/fe/src/pages/ProfilePage.tsx
+++ b/fe/src/pages/ProfilePage.tsx
@@ -1,15 +1,17 @@
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { useGetProfile } from 'service/queries/profile';
 import { styled } from 'styled-components';
 import { media } from 'styles/mediaQuery';
 import { UserFeedTabs } from 'components/common/userFeedTabs/UserFeedTabs';
 import { ProfileUserInfo } from 'components/profileUserInfo/ProfileUserInfo';
-import { getUserInfo } from 'utils/localStorage';
 
 export const ProfilePage = () => {
-  const { id } = getUserInfo();
+  const { id } = useParams();
   const { data } = useGetProfile(id);
   /* TODO. data.myFeed 데이터 생기면 추가하기 */
+  console.log(data, 'profile data');
+
   const [index, setIndex] = useState(0);
 
   const handleFeedTab = (index: number) => {

--- a/fe/src/routes/router.tsx
+++ b/fe/src/routes/router.tsx
@@ -56,6 +56,10 @@ const router = createBrowserRouter([
                 element: <ProfilePage />,
               },
               {
+                path: PATH.PROFILE + '/:id',
+                element: <ProfilePage />,
+              },
+              {
                 path: PATH.PROFILE_EDIT,
                 element: <ProfileEditPage />,
               },

--- a/fe/src/service/axios/follow/follow.ts
+++ b/fe/src/service/axios/follow/follow.ts
@@ -1,0 +1,12 @@
+import { privateApi } from 'service/axios/fetcher';
+import { END_POINT } from 'service/constants/endpoint';
+
+export const postFollow = async (id: string) => {
+  const { data } = await privateApi.post(END_POINT.follow(id));
+  return data;
+};
+
+export const deleteFollow = async (id: string) => {
+  const { data } = await privateApi.delete(END_POINT.follow(id));
+  return data;
+};

--- a/fe/src/service/constants/endpoint.ts
+++ b/fe/src/service/constants/endpoint.ts
@@ -19,4 +19,5 @@ export const END_POINT = {
     `/members/duplication-check?nickname=${nickname}`,
   notifications: (id?: string) =>
     id ? `/notifications/${id}` : `/notifications`,
+  follow: (id: string) => `/members/${id}/followings`,
 };

--- a/fe/src/service/queries/follow.ts
+++ b/fe/src/service/queries/follow.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { useToast } from 'recoil/toast/useToast';
+import { deleteFollow, postFollow } from 'service/axios/follow/follow';
+import { QUERY_KEY } from 'service/constants/queryKey';
+
+export const usePostFollow = (memberId: string) => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: () => postFollow(memberId),
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERY_KEY.profile, memberId]);
+    },
+    onError: (error: AxiosError<CustomErrorResponse>) => {
+      const errorData = error?.response?.data;
+
+      errorData && toast.error(errorData.message);
+    },
+  });
+};
+
+export const useDeleteFollow = (memberId: string) => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: () => deleteFollow(memberId),
+    onSuccess: () => {
+      queryClient.invalidateQueries([QUERY_KEY.profile, memberId]);
+    },
+    onError: (error: AxiosError<CustomErrorResponse>) => {
+      const errorData = error?.response?.data;
+
+      errorData && toast.error(errorData.message);
+    },
+  });
+};

--- a/fe/src/service/queries/profile.ts
+++ b/fe/src/service/queries/profile.ts
@@ -8,13 +8,17 @@ import {
   patchProfileImage,
 } from 'service/axios/profile/profile';
 import { QUERY_KEY } from 'service/constants/queryKey';
+import { useAuthState } from 'hooks/auth/useAuth';
 
-export const useGetProfile = (memberId?: string) =>
-  useQuery<ProfileMemberInfo>({
-    queryKey: [QUERY_KEY.profile, memberId],
-    queryFn: () => getProfile(memberId),
+export const useGetProfile = (memberId?: string) => {
+  const { userInfo } = useAuthState();
+  const id = memberId ? memberId : userInfo?.id;
+
+  return useQuery<ProfileMemberInfo>({
+    queryKey: [QUERY_KEY.profile, id],
+    queryFn: () => getProfile(id),
   });
-
+};
 export const useEditProfileImage = (memberId: string) => {
   const queryClient = useQueryClient();
 

--- a/fe/src/utils/generateDefaultUserImage.ts
+++ b/fe/src/utils/generateDefaultUserImage.ts
@@ -1,3 +1,3 @@
 export const generateDefaultUserImage = (userId: string) => {
-  return `https://source.boringavatars.com/beam/${userId}`;
+  return `https://source.boringavatars.com/beam/${userId}?square`;
 };


### PR DESCRIPTION
## Key changes🔧
- 팔로우 언팔로우 연동
- 댓글 유저이미지에 프로필이동 연결
- 피드 프로필 (상세페이지, 메인) 유저이미지에 프로필이동 연결
  - 빠진 연결부 있으면 알려주시오

## To reviewer👋
- 팔로우 언팔로우 확인할때 가입 귀찮으실테니 만들어둔 아이디로 확인해보세여

id: lion99@gmail.com
pw: lion99@gmail

id: rhino99@gmail.com
pw: rhino99@gmail


- **프로필 플로우 리마인드**: 현재 프로필 조회 api상 토큰이 있어야만 플필데이터를 불러올 수 있음 
=> 로그인하지 않은 사용자는 내 프로필&다른 사람프로필 둘 다 접근 불가,   
  - 로그인을 안하면 홈에서 전체 피드만 볼 수 있음 