### PR TITLE
[Be] Feed, Collection의 isLiked 로직 수정

### DIFF
--- a/be/src/main/java/com/foodymoody/be/common/exception/ErrorMessage.java
+++ b/be/src/main/java/com/foodymoody/be/common/exception/ErrorMessage.java
@@ -41,7 +41,8 @@ public enum ErrorMessage {
     INVALID_IMAGE_URL("유효하지 않은 이미지 url입니다", "i006"),
     MAX_UPLOAD_SIZE_EXEEDED("2.8MB 이하의 이미지만 업로드 가능합니다", "i007"),
     INVALID_IMAGE_ID("유효하지 않은 이미지 id입니다", "i008"),
-    MENU_NOT_FOUND("유효하지 않은 메뉴 id입니다.", "i010");
+    MENU_NOT_FOUND("유효하지 않은 메뉴 id입니다.", "i010"),
+    IS_LIKED_NOT_EXISTS("isLiked를 찾아올 수 없습니다.", "i012");
 
     private final String message;
     private final String code;

--- a/be/src/main/java/com/foodymoody/be/common/exception/IsLikedNotExistsException.java
+++ b/be/src/main/java/com/foodymoody/be/common/exception/IsLikedNotExistsException.java
@@ -1,0 +1,9 @@
+package com.foodymoody.be.common.exception;
+
+public class IsLikedNotExistsException extends BusinessException {
+
+    public IsLikedNotExistsException() {
+        super(ErrorMessage.IS_LIKED_NOT_EXISTS);
+    }
+
+}

--- a/be/src/main/java/com/foodymoody/be/feed/application/FeedMapper.java
+++ b/be/src/main/java/com/foodymoody/be/feed/application/FeedMapper.java
@@ -52,7 +52,8 @@ public class FeedMapper {
 
     public static FeedReadResponse toFeedReadResponse(FeedMemberResponse feedMemberResponse, Feed feed,
                                                       List<FeedImageMenuResponse> images,
-                                                      List<FeedStoreMoodResponse> moodNames) {
+                                                      List<FeedStoreMoodResponse> moodNames,
+                                                      boolean isLiked) {
         return FeedReadResponse.builder()
                 .id(feed.getId())
                 .member(feedMemberResponse)
@@ -62,7 +63,7 @@ public class FeedMapper {
                 .images(images)
                 .createdAt(feed.getCreatedAt())
                 .updatedAt(feed.getUpdatedAt())
-                .isLiked(feed.isLiked())
+                .isLiked(isLiked)
                 .likeCount(feed.getLikeCount())
                 .commentCount(feed.getCommentCount())
                 .build();
@@ -121,7 +122,8 @@ public class FeedMapper {
 
     public static FeedReadAllResponse makeFeedReadAllResponse(Feed feed, FeedMemberResponse makeFeedMemberResponse,
                                                               List<FeedStoreMoodResponse> makeFeedStoreMoodResponses,
-                                                              List<FeedImageMenuResponse> makeFeedImageMenuResponses) {
+                                                              List<FeedImageMenuResponse> makeFeedImageMenuResponses,
+                                                              boolean isLiked) {
         return FeedReadAllResponse.builder()
                 .id(feed.getId())
                 .member(makeFeedMemberResponse)
@@ -132,7 +134,7 @@ public class FeedMapper {
                 .createdAt(feed.getCreatedAt())
                 .updatedAt(feed.getUpdatedAt())
                 .commentCount(feed.getCommentCount())
-                .isLiked(feed.isLiked())
+                .isLiked(isLiked)
                 .likeCount(feed.getLikeCount())
                 .build();
     }
@@ -144,8 +146,9 @@ public class FeedMapper {
     }
 
     public static CollectionReadFeedListServiceRequest toCollectionServiceReadAllFeedRequest(String collectionId,
-                                                                                             Pageable pageable) {
-        return new CollectionReadFeedListServiceRequest(collectionId, pageable);
+                                                                                             Pageable pageable,
+                                                                                             MemberId memberId) {
+        return new CollectionReadFeedListServiceRequest(collectionId, pageable, memberId);
     }
 
     public static List<String> toFeedStoreMoodNames(List<StoreMood> storeMoods) {

--- a/be/src/main/java/com/foodymoody/be/feed/application/FeedReadService.java
+++ b/be/src/main/java/com/foodymoody/be/feed/application/FeedReadService.java
@@ -2,9 +2,11 @@ package com.foodymoody.be.feed.application;
 
 import com.foodymoody.be.common.exception.FeedIdNotExistsException;
 import com.foodymoody.be.common.exception.ImageNotFoundException;
+import com.foodymoody.be.common.exception.IsLikedNotExistsException;
 import com.foodymoody.be.common.exception.MenuNotFoundException;
 import com.foodymoody.be.common.util.ids.FeedId;
 import com.foodymoody.be.common.util.ids.IdFactory;
+import com.foodymoody.be.common.util.ids.MemberId;
 import com.foodymoody.be.feed.domain.entity.Feed;
 import com.foodymoody.be.feed.domain.entity.ImageMenu;
 import com.foodymoody.be.feed.domain.repository.FeedRepository;
@@ -67,6 +69,11 @@ public class FeedReadService {
 
     public Slice<Feed> findAllByIdIn(List<FeedId> feedIds, Pageable pageable) {
         return feedRepository.findAllByIdIn(feedIds, pageable);
+    }
+
+    public boolean fetchIsLikedByMemberId(FeedId feedId, MemberId memberId) {
+        return feedJpaRepository.fetchIsLikedByMemberId(feedId, memberId)
+                .orElseThrow(IsLikedNotExistsException::new);
     }
 
 }

--- a/be/src/main/java/com/foodymoody/be/feed/application/dto/request/CollectionReadFeedListServiceRequest.java
+++ b/be/src/main/java/com/foodymoody/be/feed/application/dto/request/CollectionReadFeedListServiceRequest.java
@@ -2,6 +2,7 @@ package com.foodymoody.be.feed.application.dto.request;
 
 import com.foodymoody.be.common.util.ids.FeedCollectionId;
 import com.foodymoody.be.common.util.ids.IdFactory;
+import com.foodymoody.be.common.util.ids.MemberId;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -11,10 +12,13 @@ public class CollectionReadFeedListServiceRequest {
 
     private FeedCollectionId feedCollectionId;
     private Pageable pageable;
+    private MemberId memberId;
 
-    public CollectionReadFeedListServiceRequest(String collectionId, Pageable pageable) {
-        this.feedCollectionId = IdFactory.createFeedCollectionId(collectionId);
+    public CollectionReadFeedListServiceRequest(String feedCollectionId, Pageable pageable,
+                                                MemberId memberId) {
+        this.feedCollectionId = IdFactory.createFeedCollectionId(feedCollectionId);
         this.pageable = pageable;
+        this.memberId = memberId;
     }
 
     public FeedCollectionId getFeedCollectionId() {
@@ -31,6 +35,14 @@ public class CollectionReadFeedListServiceRequest {
 
     public void setPageable(Pageable pageable) {
         this.pageable = pageable;
+    }
+
+    public MemberId getMemberId() {
+        return memberId;
+    }
+
+    public void setMemberId(MemberId memberId) {
+        this.memberId = memberId;
     }
 
 }

--- a/be/src/main/java/com/foodymoody/be/feed/domain/entity/Feed.java
+++ b/be/src/main/java/com/foodymoody/be/feed/domain/entity/Feed.java
@@ -30,7 +30,6 @@ public class Feed {
     private LocalDateTime updatedAt;
     private String review;
     private int likeCount;
-    private boolean isLiked;
     private int commentCount;
 
     @ManyToMany(fetch = FetchType.LAZY)
@@ -76,10 +75,6 @@ public class Feed {
         return likeCount;
     }
 
-    public boolean isLiked() {
-        return isLiked;
-    }
-
     public int getCommentCount() {
         return commentCount;
     }
@@ -111,10 +106,6 @@ public class Feed {
         this.profileImageUrl = profileImageUrl;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
-    }
-
-    public void updateIsLikedBy(boolean isLiked) {
-        this.isLiked = isLiked;
     }
 
     public void updateLikeCountBy(int heartCount) {

--- a/be/src/main/java/com/foodymoody/be/feed/infra/persistence/jpa/FeedJpaRepository.java
+++ b/be/src/main/java/com/foodymoody/be/feed/infra/persistence/jpa/FeedJpaRepository.java
@@ -26,7 +26,10 @@ public interface FeedJpaRepository extends JpaRepository<Feed, FeedId> {
             "WHERE im IN :imageMenus")
     Optional<List<MenuNameRatingPair>> fetchMenuNameRatingList(@Param("imageMenus") List<ImageMenu> imageMenus);
 
-    @Query("SELECT fh.isLiked FROM FeedHeart fh WHERE fh.feedId = :feedId AND fh.memberId = :memberId")
+    @Query("SELECT fh.isLiked "
+            + "FROM FeedHeart fh "
+            + "WHERE fh.feedId = :feedId "
+            + "AND fh.memberId = :memberId")
     Optional<Boolean> fetchIsLikedByMemberId(@Param("feedId") FeedId feedId, @Param("memberId") MemberId memberId);
 
 }

--- a/be/src/main/java/com/foodymoody/be/feed/infra/persistence/jpa/FeedJpaRepository.java
+++ b/be/src/main/java/com/foodymoody/be/feed/infra/persistence/jpa/FeedJpaRepository.java
@@ -1,6 +1,7 @@
 package com.foodymoody.be.feed.infra.persistence.jpa;
 
 import com.foodymoody.be.common.util.ids.FeedId;
+import com.foodymoody.be.common.util.ids.MemberId;
 import com.foodymoody.be.feed.domain.entity.Feed;
 import com.foodymoody.be.feed.domain.entity.ImageMenu;
 import com.foodymoody.be.feed.infra.usecase.dto.ImageIdNamePair;
@@ -24,5 +25,8 @@ public interface FeedJpaRepository extends JpaRepository<Feed, FeedId> {
             "JOIN Menu m ON im.menuId = m.id " +
             "WHERE im IN :imageMenus")
     Optional<List<MenuNameRatingPair>> fetchMenuNameRatingList(@Param("imageMenus") List<ImageMenu> imageMenus);
+
+    @Query("SELECT fh.isLiked FROM FeedHeart fh WHERE fh.feedId = :feedId AND fh.memberId = :memberId")
+    Optional<Boolean> fetchIsLikedByMemberId(@Param("feedId") FeedId feedId, @Param("memberId") MemberId memberId);
 
 }

--- a/be/src/main/java/com/foodymoody/be/feed/presentation/CollectionController.java
+++ b/be/src/main/java/com/foodymoody/be/feed/presentation/CollectionController.java
@@ -1,5 +1,7 @@
 package com.foodymoody.be.feed.presentation;
 
+import com.foodymoody.be.common.annotation.CurrentMemberId;
+import com.foodymoody.be.common.util.ids.MemberId;
 import com.foodymoody.be.feed.application.FeedMapper;
 import com.foodymoody.be.feed.application.dto.response.CollectionReadAllFeedResponse;
 import com.foodymoody.be.feed.infra.usecase.CollectionUseCase;
@@ -22,9 +24,10 @@ public class CollectionController {
      */
     @GetMapping("/api/collections/{collectionId}/feeds")
     public ResponseEntity<Slice<CollectionReadAllFeedResponse>> readFeedCollectionDetail(
-            @PathVariable String collectionId, Pageable pageable) {
+            @PathVariable String collectionId, Pageable pageable,
+            @CurrentMemberId MemberId memberId) {
         Slice<CollectionReadAllFeedResponse> collectionReadAllResponses = collectionUseCase.readFeedCollectionDetail(
-                FeedMapper.toCollectionServiceReadAllFeedRequest(collectionId, pageable));
+                FeedMapper.toCollectionServiceReadAllFeedRequest(collectionId, pageable, memberId));
         return ResponseEntity.ok().body(collectionReadAllResponses);
     }
 

--- a/be/src/main/java/com/foodymoody/be/feed/presentation/FeedController.java
+++ b/be/src/main/java/com/foodymoody/be/feed/presentation/FeedController.java
@@ -44,8 +44,9 @@ public class FeedController {
      * 전체 Feed 조회
      */
     @GetMapping("/api/feeds")
-    public ResponseEntity<Slice<FeedReadAllResponse>> readAll(Pageable pageable) {
-        Slice<FeedReadAllResponse> feedReadAllResponses = feedUseCase.readAll(pageable);
+    public ResponseEntity<Slice<FeedReadAllResponse>> readAll(Pageable pageable,
+                                                              @CurrentMemberId MemberId memberId) {
+        Slice<FeedReadAllResponse> feedReadAllResponses = feedUseCase.readAll(pageable, memberId);
         return ResponseEntity.ok().body(feedReadAllResponses);
     }
 
@@ -53,8 +54,9 @@ public class FeedController {
      * 개별 Feed 조회
      */
     @GetMapping("/api/feeds/{id}")
-    public ResponseEntity<FeedReadResponse> read(@PathVariable String id) {
-        FeedReadResponse feedReadResponse = feedUseCase.read(id);
+    public ResponseEntity<FeedReadResponse> read(@PathVariable String id,
+                                                 @CurrentMemberId MemberId memberId) {
+        FeedReadResponse feedReadResponse = feedUseCase.read(id, memberId);
         return ResponseEntity.ok().body(feedReadResponse);
     }
 

--- a/be/src/main/java/com/foodymoody/be/feed_heart/application/FeedHeartMapper.java
+++ b/be/src/main/java/com/foodymoody/be/feed_heart/application/FeedHeartMapper.java
@@ -13,8 +13,8 @@ public class FeedHeartMapper {
     }
 
     public static FeedHeart makeFeedHeartWithFeedIdAndMemberId(FeedHeartId feedHeartId, FeedId feedId,
-                                                               MemberId memberId) {
-        return new FeedHeart(feedHeartId, feedId, memberId);
+                                                               MemberId memberId, boolean isLiked) {
+        return new FeedHeart(feedHeartId, feedId, memberId, isLiked);
     }
 
     public static FeedHeartResponse toHeartResponse(String id, String feedId, String memberId, boolean isLiked,

--- a/be/src/main/java/com/foodymoody/be/feed_heart/application/FeedHeartService.java
+++ b/be/src/main/java/com/foodymoody/be/feed_heart/application/FeedHeartService.java
@@ -39,16 +39,16 @@ public class FeedHeartService {
 
         FeedHeart feedHeart = FeedHeartMapper
                 .makeFeedHeartWithFeedIdAndMemberId(IdFactory.createFeedHeartId(), IdFactory.createFeedId(feedStringId),
-                        memberId);
+                        memberId, true);
         FeedHeart savedFeedHeart = feedHeartRepository.save(feedHeart);
 
         feedHeartCountService.incrementFeedHeartCount(feedStringId);
 
         FeedHeartCount feedHeartCount = feedHeartCountService.findFeedHeartCountByFeedId(feedStringId);
-        Feed feed = updateFeed(feedStringId, feedHeartCount.getCount(), true);
+        updateFeed(feedStringId, feedHeartCount.getCount());
 
         return FeedHeartMapper.toHeartResponse(savedFeedHeart.getId().getValue(), savedFeedHeart.getFeedId().getValue(),
-                savedFeedHeart.getMemberId().getValue(), feed.isLiked(), feedHeartCount.getCount());
+                savedFeedHeart.getMemberId().getValue(), savedFeedHeart.isLiked(), feedHeartCount.getCount());
     }
 
     @Transactional
@@ -66,17 +66,14 @@ public class FeedHeartService {
         feedHeartCountService.decrementFeedHeartCount(feedStringId);
 
         FeedHeartCount feedHeartCount = feedHeartCountService.findFeedHeartCountByFeedId(feedStringId);
-        updateFeed(feedStringId, feedHeartCount.getCount(), false);
+        updateFeed(feedStringId, feedHeartCount.getCount());
     }
 
-    private Feed updateFeed(String feedId, int heartCount, boolean isLiked) {
+    private void updateFeed(String feedId, int heartCount) {
         FeedId feedIdObj = IdFactory.createFeedId(feedId);
         Feed feed = feedReadService.findFeed(feedIdObj);
 
-        feed.updateIsLikedBy(isLiked);
         feed.updateLikeCountBy(heartCount);
-
-        return feed;
     }
 
     private boolean existsHeart(MemberId memberId, String feedId) {

--- a/be/src/main/java/com/foodymoody/be/feed_heart/domain/entity/FeedHeart.java
+++ b/be/src/main/java/com/foodymoody/be/feed_heart/domain/entity/FeedHeart.java
@@ -20,11 +20,13 @@ public class FeedHeart {
     private FeedId feedId;
     @AttributeOverride(name = "value", column = @Column(name = "member_id"))
     private MemberId memberId;
+    private boolean isLiked;
 
-    public FeedHeart(FeedHeartId id, FeedId feedId, MemberId memberId) {
+    public FeedHeart(FeedHeartId id, FeedId feedId, MemberId memberId, boolean isLiked) {
         this.id = id;
         this.feedId = feedId;
         this.memberId = memberId;
+        this.isLiked = isLiked;
     }
 
     public FeedHeartId getId() {
@@ -37,6 +39,10 @@ public class FeedHeart {
 
     public MemberId getMemberId() {
         return memberId;
+    }
+
+    public boolean isLiked() {
+        return isLiked;
     }
 
 }

--- a/be/src/main/resources/application-filter.yml
+++ b/be/src/main/resources/application-filter.yml
@@ -3,6 +3,6 @@ filter:
     POST /api/auth/login, POST /api/auth/token,
     POST /api/members, GET /api/members/.*, GET /api/members/duplication-check,
     GET /api/feeds, GET /api/feeds/.*,
-    GET /api/comments,
+    GET /api/comments, GET /api/collections/.*/feeds
     GET /api/moods/random, GET /api/moods, GET /api/moods/.*, POST /api/moods,
     POST /api/images,GET /api/comments/.*/replies,GET /api/comments/.*/replies/.*,

--- a/be/src/main/resources/application-filter.yml
+++ b/be/src/main/resources/application-filter.yml
@@ -3,6 +3,6 @@ filter:
     POST /api/auth/login, POST /api/auth/token,
     POST /api/members, GET /api/members/.*, GET /api/members/duplication-check,
     GET /api/feeds, GET /api/feeds/.*,
-    GET /api/comments, GET /api/collections/.*/feeds
+    GET /api/comments, GET /api/collections/.*/feeds,
     GET /api/moods/random, GET /api/moods, GET /api/moods/.*, POST /api/moods,
     POST /api/images,GET /api/comments/.*/replies,GET /api/comments/.*/replies/.*,

--- a/be/src/test/java/com/foodymoody/be/acceptance/feed_heart/FeedHeartAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/feed_heart/FeedHeartAcceptanceTest.java
@@ -1,12 +1,12 @@
-package com.foodymoody.be.acceptance.heart;
+package com.foodymoody.be.acceptance.feed_heart;
 
 import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_등록한다;
-import static com.foodymoody.be.acceptance.heart.FeedHeartSteps.응답코드가_200이고_id가_존재하면_정상적으로_좋아요_가능;
-import static com.foodymoody.be.acceptance.heart.FeedHeartSteps.응답코드가_204이면_정상적으로_좋아요_취소;
-import static com.foodymoody.be.acceptance.heart.FeedHeartSteps.좋아요_취소를_한다;
-import static com.foodymoody.be.acceptance.heart.FeedHeartSteps.좋아요_한_적이_없는데_좋아요_취소를_한다;
-import static com.foodymoody.be.acceptance.heart.FeedHeartSteps.좋아요된_피드에_또_좋아요를_한다;
-import static com.foodymoody.be.acceptance.heart.FeedHeartSteps.좋아요를_한다;
+import static com.foodymoody.be.acceptance.feed_heart.FeedHeartSteps.응답코드가_200이고_id가_존재하면_정상적으로_좋아요_가능;
+import static com.foodymoody.be.acceptance.feed_heart.FeedHeartSteps.응답코드가_204이면_정상적으로_좋아요_취소;
+import static com.foodymoody.be.acceptance.feed_heart.FeedHeartSteps.좋아요_취소를_한다;
+import static com.foodymoody.be.acceptance.feed_heart.FeedHeartSteps.좋아요_한_적이_없는데_좋아요_취소를_한다;
+import static com.foodymoody.be.acceptance.feed_heart.FeedHeartSteps.좋아요된_피드에_또_좋아요를_한다;
+import static com.foodymoody.be.acceptance.feed_heart.FeedHeartSteps.좋아요를_한다;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
 import org.junit.jupiter.api.AfterEach;

--- a/be/src/test/java/com/foodymoody/be/acceptance/feed_heart/FeedHeartSteps.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/feed_heart/FeedHeartSteps.java
@@ -1,4 +1,4 @@
-package com.foodymoody.be.acceptance.heart;
+package com.foodymoody.be.acceptance.feed_heart;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/be/src/test/java/com/foodymoody/be/feed/application/FeedMapperTest.java
+++ b/be/src/test/java/com/foodymoody/be/feed/application/FeedMapperTest.java
@@ -95,7 +95,7 @@ class FeedMapperTest {
         List<FeedStoreMoodResponse> moodNames = makeFeedStoreMoodResponse();
 
         // when
-        FeedReadResponse feedReadResponse = FeedMapper.toFeedReadResponse(feedMemberResponse, feed, images, moodNames);
+        FeedReadResponse feedReadResponse = FeedMapper.toFeedReadResponse(feedMemberResponse, feed, images, moodNames, false);
 
         // then
         assertAll(() -> {
@@ -123,7 +123,8 @@ class FeedMapperTest {
         // when
         FeedReadAllResponse feedReadAllResponse = FeedMapper.makeFeedReadAllResponse(feed, makeFeedMemberResponse,
                 makeFeedStoreMoodResponses,
-                makeFeedImageMenuResponses);
+                makeFeedImageMenuResponses,
+                false);
 
         // then
         assertAll(() -> {


### PR DESCRIPTION
## Key changes🔧
- isLiked의 정보는 Feed의 feedId와 memberId를 가지고 FeedHeart를 찾아 가져와야 합니다.
## To reviewer👋
- isLiked를 Feed가 아닌 FeedHeart에서 가지고 있도록 했습니다.
- MemberId를 가져오기 위해 화이트리스트에 추가했습니다.
  - Feed 조회에서도 좋아요 때문에 MemberId의 정보가 필요합니다.
