### PR TITLE
[FE] 가게 정보 페이지 UI

### DIFF
--- a/fe/src/components/common/commentItem/CommentItem.tsx
+++ b/fe/src/components/common/commentItem/CommentItem.tsx
@@ -7,6 +7,7 @@ import { useAuthState } from 'hooks/auth/useAuth';
 import { useInput } from 'hooks/useInput';
 import { usePageNavigator } from 'hooks/usePageNavigator';
 import { formatTimeStamp } from 'utils/formatTimeStamp';
+import { generateDefaultUserImage } from 'utils/generateDefaultUserImage';
 import { DotGhostIcon, HeartSmallEmpty, HeartSmallFill } from '../icon/icons';
 import { Input } from '../input/Input';
 import { InputField } from '../input/InputField';
@@ -106,7 +107,10 @@ export const CommentItem: React.FC<Props> = ({ createdAt, comment }) => {
     <Wrapper>
       <ContentLeft>
         <UserImage
-          imageUrl={comment.member.imageUrl}
+          imageUrl={
+            comment.member.imageUrl ||
+            generateDefaultUserImage(comment.member.id)
+          }
           onClick={handleNavigateProfile}
         />
         <FlexColumnBox>

--- a/fe/src/components/common/feedUserInfo/FeedUserInfo.tsx
+++ b/fe/src/components/common/feedUserInfo/FeedUserInfo.tsx
@@ -38,6 +38,10 @@ export const FeedUserInfo: React.FC<Props> = ({
     navigate(PATH.PROFILE + '/' + member.id);
   };
 
+  const hadleNavigateStore = () => {
+    navigate(PATH.STORE + '/' + '1'); // 가게 id로 변경해야함
+  };
+
   const publicMenu = [
     {
       id: 1,
@@ -100,7 +104,7 @@ export const FeedUserInfo: React.FC<Props> = ({
             {isUpdated && <span>수정됨</span>}
           </ContentHeader>
 
-          <ContentBody>
+          <ContentBody onClick={hadleNavigateStore}>
             <MapPinSmallIcon />
             <p>{location}</p>
           </ContentBody>

--- a/fe/src/constants/path.ts
+++ b/fe/src/constants/path.ts
@@ -17,4 +17,5 @@ export const PATH = {
   ACCOUNT: '/account',
   FOLLOWER: '/followers',
   FOLLOWING: '/followings',
+  STORE: '/store',
 };

--- a/fe/src/pages/DetailFeedPage.tsx
+++ b/fe/src/pages/DetailFeedPage.tsx
@@ -37,7 +37,7 @@ export const DetailFeedModalPage = () => {
   });
 
   const handleNavigateToBack = () => {
-    if (background === 'detailFeed') {
+    if (background === 'detailFeed' || background === 'notiDetailFeed') {
       navigateToBack();
       closeModal('commentAlert');
     } else {

--- a/fe/src/pages/StorePage.tsx
+++ b/fe/src/pages/StorePage.tsx
@@ -110,7 +110,7 @@ const ContentWrapper = styled.div`
   border-right: 1px solid ${({ theme: { colors } }) => colors.black};
   background: ${({ theme: { colors } }) => colors.white};
   //추가한 부분
-  margin-top: 40px;
+  margin-top: 58px;
   padding: 16px;
   box-sizing: border-box;
   border: 1px solid ${({ theme: { colors } }) => colors.black};
@@ -122,6 +122,7 @@ const ContentWrapper = styled.div`
     max-width: 568px;
     width: 100%;
     //추가한 부분
+    margin-top: 40px;
     margin-bottom: 40px;
   }
 

--- a/fe/src/pages/StorePage.tsx
+++ b/fe/src/pages/StorePage.tsx
@@ -1,0 +1,266 @@
+import { useState } from 'react';
+import { useToast } from 'recoil/toast/useToast';
+import { styled } from 'styled-components';
+import { flexColumn, flexRow } from 'styles/customStyle';
+import { media } from 'styles/mediaQuery';
+import {
+  FaceIcon,
+  HeartFillIcon,
+  MapPinLargeIcon,
+  StarLargeFillIcon,
+} from 'components/common/icon/icons';
+
+export const StorePage = () => {
+  const [activeTab, setActiveTab] = useState('home');
+  const toast = useToast();
+
+  const handleTabClick = (tab: 'home' | 'feed') => {
+    setActiveTab(tab);
+  };
+
+  const address = '경기도 안양시 동안구 평촌대로223번길 16 (호계동) 2층 205호';
+
+  const handleCopyToClipBoard = async () => {
+    try {
+      await navigator.clipboard.writeText(address); //TODO실제 데이터의 가게주소로 변경 store.address
+      toast.noti('복사되었습니다');
+    } catch (e) {
+      toast.noti('다시 시도해주세요');
+    }
+  };
+
+  return (
+    <Wrapper>
+      <ContentWrapper>
+        <Header>
+          <HeaderTitle>
+            <FlexRow>
+              <StoreTitle>{'후타가와 짜장'}</StoreTitle>
+              <Rating>
+                <StarLargeFillIcon />
+                <RatingCount>{4.5}</RatingCount>
+              </Rating>
+            </FlexRow>
+            <TitleText>
+              <SubText>{'범계동'}</SubText>
+              <SubText>{'·'}</SubText>
+              <SubText>{'피드 10'}</SubText>
+            </TitleText>
+          </HeaderTitle>
+          <HeartFillIcon />
+        </Header>
+        <Tab>
+          <TabItem
+            onClick={() => handleTabClick('home')}
+            $tab={activeTab === 'home'}
+          >
+            홈
+          </TabItem>
+          <TabItem
+            onClick={() => handleTabClick('feed')}
+            $tab={activeTab === 'feed'}
+          >
+            피드
+          </TabItem>
+        </Tab>
+        <MapContent>
+          <MapContainer>
+            <SubTile>정보</SubTile>
+            <Map></Map>
+          </MapContainer>
+          <InfoContainer>
+            <Info>
+              <MapPinLargeIcon />
+              <AddressContainer>
+                <Address>
+                  {'경기도 안양시 동안구 평촌대로223번길 16 (호계동) 2층 205호'}
+                </Address>
+                <CopyContainer onClick={handleCopyToClipBoard}>
+                  <FaceIcon />
+                  <Copy>복사하기</Copy>
+                </CopyContainer>
+              </AddressContainer>
+            </Info>
+            <Info>
+              <MapPinLargeIcon />
+              <Address>{'031-383-6333'}</Address>
+            </Info>
+          </InfoContainer>
+        </MapContent>
+      </ContentWrapper>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  transition: all 0.2s ease-in-out;
+
+  //추가한 부분
+  align-items: center;
+`;
+
+const ContentWrapper = styled.div`
+  width: 566px;
+  height: 100%;
+  border-left: 1px solid ${({ theme: { colors } }) => colors.black};
+  border-right: 1px solid ${({ theme: { colors } }) => colors.black};
+  background: ${({ theme: { colors } }) => colors.white};
+  //추가한 부분
+  margin-top: 40px;
+  padding: 16px;
+  box-sizing: border-box;
+  border: 1px solid ${({ theme: { colors } }) => colors.black};
+  border-radius: 4px;
+  ${flexColumn}
+  gap: 20px;
+
+  ${media.md} {
+    max-width: 568px;
+    width: 100%;
+    //추가한 부분
+    margin-bottom: 40px;
+  }
+
+  ${media.xs} {
+    border-left: none;
+    border-right: none;
+
+    //추가한 부분
+    margin-top: 0;
+    margin-bottom: 55px;
+  }
+`;
+
+const Header = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+`;
+
+const HeaderTitle = styled.div`
+  ${flexColumn}
+  width: 100%;
+`;
+
+const FlexRow = styled.div`
+  ${flexRow}
+  align-items: center;
+  gap: 8px;
+`;
+
+const StoreTitle = styled.div`
+  font: ${({ theme: { fonts } }) => fonts.displayB20};
+`;
+
+const Rating = styled.div`
+  ${flexRow}
+  align-items: center;
+  gap: 4px;
+  cursor: default;
+`;
+
+const RatingCount = styled.p`
+  font: ${({ theme: { fonts } }) => fonts.displayM14};
+`;
+
+const TitleText = styled.div`
+  ${flexRow}
+  gap: 4px;
+`;
+
+const SubText = styled.p`
+  font: ${({ theme: { fonts } }) => fonts.displayM14};
+`;
+
+const Tab = styled.div`
+  ${flexRow}
+  width: 100%;
+  height: 48px;
+`;
+
+const TabItem = styled.div<{ $tab: boolean }>`
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-bottom: 1px solid
+    ${({ $tab, theme: { colors } }) => ($tab ? colors.orange : colors.black)};
+  color: ${({ $tab, theme: { colors } }) =>
+    $tab ? colors.orange : colors.black};
+  font: ${({ $tab, theme: { fonts } }) =>
+    $tab ? fonts.displayB16 : fonts.displayM16};
+  transition: all 0.2s ease-in-out;
+`;
+
+const MapContent = styled.div`
+  ${flexColumn}
+  width: 100%;
+  height: 100%;
+  gap: 20px;
+`;
+
+const MapContainer = styled.div`
+  width: 100%;
+  ${flexColumn}
+  gap: 8px;
+`;
+
+const SubTile = styled.p`
+  font: ${({ theme: { fonts } }) => fonts.displayB16};
+`;
+
+const Map = styled.div`
+  width: 100%;
+  height: 400px; // media
+  border: 1px solid ${({ theme: { colors } }) => colors.black};
+  ${media.md} {
+    height: 400px;
+  }
+
+  ${media.xs} {
+    height: 320px;
+  }
+`;
+
+const InfoContainer = styled.div`
+  ${flexColumn}
+  width: 100%;
+  height: 100%;
+  gap: 16px;
+`;
+
+const Info = styled.div`
+  ${flexRow}
+  width: 100%;
+  /* height: 48px; */
+  gap: 8px;
+`;
+
+const AddressContainer = styled.p`
+  ${flexRow}
+  flex-wrap: wrap;
+  width: 100%;
+  gap: 4px;
+`;
+
+const Address = styled.p`
+  font: ${({ theme: { fonts } }) => fonts.displayM14};
+`;
+
+const CopyContainer = styled.div`
+  ${flexRow}
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+`;
+
+const Copy = styled.p`
+  font: ${({ theme: { fonts } }) => fonts.displayM12};
+  color: ${({ theme: { colors } }) => colors.textSecondary};
+`;

--- a/fe/src/routes/router.tsx
+++ b/fe/src/routes/router.tsx
@@ -17,6 +17,7 @@ import { ProtectedRoute } from 'pages/ProtectedRoute';
 import { RegisterPage } from 'pages/RegisterPage';
 import { SearchPage } from 'pages/SearchPage';
 import { SettingPage } from 'pages/SettingPage';
+import { StorePage } from 'pages/StorePage';
 import { PATH } from 'constants/path';
 
 const router = createBrowserRouter([
@@ -110,6 +111,10 @@ const router = createBrowserRouter([
           {
             path: PATH.SEARCH,
             element: <SearchPage />,
+          },
+          {
+            path: PATH.STORE + '/:id',
+            element: <StorePage />,
           },
         ],
       },


### PR DESCRIPTION
## Key changes🔧
- 라우트연결: 피드의 가게 위치 클릭시 가게 정보 페이지로 이동할 수 있습니다
![image](https://github.com/foody-moody/foodymoody/assets/86706366/ed1fd72f-1ee9-4619-988c-acc2132d3600)
- 홈/피드 탭전환 기능
- 복사하기 기능: 간단한 api가 있네요
  - [참고한 링크](https://code00.tistory.com/170)
- phone, 복사하기 이모지 추가는 아직..
## To reviewer👋
- PC
![image](https://github.com/foody-moody/foodymoody/assets/86706366/83f75221-b61d-4cc3-a47d-bc02575d67a8)
- 태블릿
![image](https://github.com/foody-moody/foodymoody/assets/86706366/45841fb4-a999-43fe-a00a-f41554517558)
- 모바일 
![image](https://github.com/foody-moody/foodymoody/assets/86706366/08d281bf-22fc-4476-b86b-77870973077c)

