### PR TITLE
[BE] 피드 삭제 시에 이미지도 soft delete로 삭제되도록 구현

### DIFF
--- a/be/src/main/java/com/foodymoody/be/feed/application/FeedMapper.java
+++ b/be/src/main/java/com/foodymoody/be/feed/application/FeedMapper.java
@@ -21,6 +21,7 @@ import com.foodymoody.be.feed.application.dto.response.FeedRegisterResponse;
 import com.foodymoody.be.feed.application.dto.response.FeedStoreMoodResponse;
 import com.foodymoody.be.feed.application.dto.response.FeedTasteMoodResponse;
 import com.foodymoody.be.feed.domain.entity.Feed;
+import com.foodymoody.be.feed.domain.entity.ImageMenu;
 import com.foodymoody.be.feed.domain.entity.StoreMood;
 import com.foodymoody.be.feed.infra.usecase.dto.ImageIdNamePair;
 import com.foodymoody.be.feed.infra.usecase.dto.MenuNameRatingPair;
@@ -163,6 +164,12 @@ public class FeedMapper {
                 .findFirst()
                 .orElseThrow(ImageNotFoundException::new)
                 .getImageId();
+    }
+
+    public static List<ImageId> makeImageIds(List<ImageMenu> imageMenus) {
+        return imageMenus.stream()
+                .map(ImageMenu::getImageId)
+                .collect(Collectors.toList());
     }
 
 }

--- a/be/src/test/java/com/foodymoody/be/acceptance/comment/CommentAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/comment/CommentAcceptanceTest.java
@@ -22,8 +22,10 @@ import static com.foodymoody.be.acceptance.comment.CommentSteps.피드에_여러
 import static com.foodymoody.be.acceptance.comment.CommentSteps.피드에서_200자_넘는_댓글을_등록한다;
 import static com.foodymoody.be.acceptance.comment_heart.CommentHeartSteps.댓글에_좋아요를_누른다;
 import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_등록하고_아이디를_받는다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -40,7 +42,13 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
         @BeforeEach
         void setFeedId() {
-            feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰);
+            var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+            String id1 = imageResponse1.jsonPath().getString("id");
+            var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+            String id2 = imageResponse2.jsonPath().getString("id");
+            List<String> imageIds = List.of(id1, id2);
+
+            feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds);
         }
 
         @DisplayName("댓글 등록 요청시 성공하면, 응답코드 200을 응답한다")
@@ -161,7 +169,13 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
         @BeforeEach
         void setUp() {
-            feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰);
+            var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+            String id1 = imageResponse1.jsonPath().getString("id");
+            var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+            String id2 = imageResponse2.jsonPath().getString("id");
+            List<String> imageIds = List.of(id1, id2);
+
+            feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds);
             commentId = 피드에_댓글을_등록하고_아이디를_받는다(feedId, 회원아티_액세스토큰);
         }
 
@@ -272,7 +286,13 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
         @BeforeEach
         void setUp() {
-            feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰);
+            var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+            String id1 = imageResponse1.jsonPath().getString("id");
+            var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+            String id2 = imageResponse2.jsonPath().getString("id");
+            List<String> imageIds = List.of(id1, id2);
+
+            feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds);
             commentId = 피드에_댓글을_등록하고_아이디를_받는다(feedId, 회원아티_액세스토큰);
         }
 
@@ -328,7 +348,13 @@ class CommentAcceptanceTest extends AcceptanceTest {
 
         @BeforeEach
         void setUp() {
-            feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰);
+            var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+            String id1 = imageResponse1.jsonPath().getString("id");
+            var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+            String id2 = imageResponse2.jsonPath().getString("id");
+            List<String> imageIds = List.of(id1, id2);
+
+            feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds);
             for (int i = 0; i < 20; i++) {
                 피드에_댓글을_등록한다(feedId, 회원아티_액세스토큰);
             }

--- a/be/src/test/java/com/foodymoody/be/acceptance/comment_heart/CommentFeedHeartAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/comment_heart/CommentFeedHeartAcceptanceTest.java
@@ -4,10 +4,13 @@ import static com.foodymoody.be.acceptance.comment.CommentSteps.피드에_댓글
 import static com.foodymoody.be.acceptance.comment_heart.CommentHeartSteps.댓글에_좋아요를_누른다;
 import static com.foodymoody.be.acceptance.comment_heart.CommentHeartSteps.댓글에_좋아요를_취소한다;
 import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_등록하고_아이디를_받는다;
+import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_등록한다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
 import io.restassured.builder.RequestSpecBuilder;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,7 +23,13 @@ class CommentFeedHeartAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        feedId = 피드를_등록하고_아이디를_받는다(회원푸반_액세스토큰);
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        List<String> imageIds = List.of(id1, id2);
+
+        feedId = 피드를_등록하고_아이디를_받는다(회원푸반_액세스토큰, imageIds);
         commentId = 피드에_댓글을_등록하고_아이디를_받는다(feedId, 회원아티_액세스토큰);
     }
 

--- a/be/src/test/java/com/foodymoody/be/acceptance/feed/FeedAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/feed/FeedAcceptanceTest.java
@@ -12,8 +12,10 @@ import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_등록한다
 import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_또_등록한다;
 import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_삭제한다;
 import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_수정한다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +35,8 @@ class FeedAcceptanceTest extends AcceptanceTest {
         api_문서_타이틀("registerFeed", spec);
 
         // given,when
-        var response = 피드를_등록한다(회원아티_액세스토큰, spec);
+        List<String> imageIds = 피드_이미지_업로드_후_id_리스트를_반환한다();
+        var response = 피드를_등록한다(회원아티_액세스토큰, spec, imageIds);
 
         // then
         응답코드가_200이고_id가_존재하면_정상적으로_등록된_피드(response);
@@ -46,8 +49,10 @@ class FeedAcceptanceTest extends AcceptanceTest {
         api_문서_타이틀("readAllFeed", spec);
 
         // when
-        피드를_등록한다(회원아티_액세스토큰, spec);
-        피드를_또_등록한다(회원푸반_액세스토큰, spec);
+        List<String> imageIds = 피드_이미지_업로드_후_id_리스트를_반환한다();
+        피드를_등록한다(회원아티_액세스토큰, spec, imageIds);
+        List<String> imageIdsAgain = 피드_이미지_업로드_후_id_리스트를_반환한다();
+        피드를_또_등록한다(회원푸반_액세스토큰, spec, imageIdsAgain);
         var readFeedResponse = 전체_피드를_조회한다(spec, 0, 10);
 
         // then
@@ -61,8 +66,9 @@ class FeedAcceptanceTest extends AcceptanceTest {
         api_문서_타이틀("readFeed", spec);
 
         // given
-        var registerResponse = 피드를_등록한다(회원아티_액세스토큰);
-        String registeredId = registerResponse.jsonPath().getString("id");
+        List<String> imageIds = 피드_이미지_업로드_후_id_리스트를_반환한다();
+        var response = 피드를_등록한다(회원아티_액세스토큰, spec, imageIds);
+        String registeredId = response.jsonPath().getString("id");
 
         // when
         var readFeedResponse = 개별_피드를_조회한다(registeredId, spec);
@@ -78,8 +84,9 @@ class FeedAcceptanceTest extends AcceptanceTest {
         api_문서_타이틀("updateFeed", spec);
 
         // given
-        var registerResponse = 피드를_등록한다(회원아티_액세스토큰);
-        String registeredId = registerResponse.jsonPath().getString("id");
+        List<String> imageIds = 피드_이미지_업로드_후_id_리스트를_반환한다();
+        var response = 피드를_등록한다(회원아티_액세스토큰, spec, imageIds);
+        String registeredId = response.jsonPath().getString("id");
 
         // when
         var updateResponse = 피드를_수정한다(회원아티_액세스토큰, registeredId, spec);
@@ -95,8 +102,9 @@ class FeedAcceptanceTest extends AcceptanceTest {
         api_문서_타이틀("deleteFeed", spec);
 
         // given
-        var registerResponse = 피드를_등록한다(회원아티_액세스토큰);
-        String registeredId = registerResponse.jsonPath().getString("id");
+        List<String> imageIds = 피드_이미지_업로드_후_id_리스트를_반환한다();
+        var response = 피드를_등록한다(회원아티_액세스토큰, spec, imageIds);
+        String registeredId = response.jsonPath().getString("id");
 
         // when
         var deleteResponse = 피드를_삭제한다(회원아티_액세스토큰, registeredId, spec);
@@ -116,6 +124,14 @@ class FeedAcceptanceTest extends AcceptanceTest {
 
         // then
         응답코드가_200이고_전체_스토어_무드가_조회되면_정상적으로_조회_가능한_전체_스토어_무드(response);
+    }
+
+    public List<String> 피드_이미지_업로드_후_id_리스트를_반환한다() {
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        return List.of(id1, id2);
     }
 
 }

--- a/be/src/test/java/com/foodymoody/be/acceptance/feed/FeedSteps.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/feed/FeedSteps.java
@@ -41,29 +41,29 @@ public class FeedSteps {
     }
 
 
-    public static ExtractableResponse<Response> 피드를_등록한다(String accessToken) {
-        return 피드를_등록한다(accessToken, new RequestSpecBuilder().build());
+    public static ExtractableResponse<Response> 피드를_등록한다(String accessToken, List<String> imageIds) {
+        return 피드를_등록한다(accessToken, new RequestSpecBuilder().build(), imageIds);
     }
 
-    public static String 피드를_등록하고_아이디를_받는다(String accessToken) {
-        return 피드를_등록한다(accessToken, new RequestSpecBuilder().build()).jsonPath().getString("id");
+    public static String 피드를_등록하고_아이디를_받는다(String accessToken, List<String> imageIds) {
+        return 피드를_등록한다(accessToken, new RequestSpecBuilder().build(), imageIds).jsonPath().getString("id");
     }
 
-    public static ExtractableResponse<Response> 피드를_등록한다(String accessToken, RequestSpecification spec) {
+    public static ExtractableResponse<Response> 피드를_등록한다(String accessToken, RequestSpecification spec, List<String> imageIds) {
         Map<String, Object> body = Map.of(
                 "location", "역삼동",
                 "review", "맛있어요!",
                 "storeMoodIds", List.of("1", "3", "4"),
                 "images", List.of(
                         Map.of(
-                                "imageId", "1",
+                                "imageId", imageIds.get(0),
                                 "menu", Map.of(
                                         "name", "마라탕",
                                         "rating", 4
                                 )
                         ),
                         Map.of(
-                                "imageId", "2",
+                                "imageId", imageIds.get(1),
                                 "menu", Map.of(
                                         "name", "감자탕",
                                         "rating", 3
@@ -87,21 +87,21 @@ public class FeedSteps {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 피드를_또_등록한다(String accessToken, RequestSpecification spec) {
+    public static ExtractableResponse<Response> 피드를_또_등록한다(String accessToken, RequestSpecification spec, List<String> imageIds) {
         Map<String, Object> body = Map.of(
                 "location", "중동",
                 "review", "맛없어요!",
                 "storeMoodIds", List.of("1", "2", "4"),
                 "images", List.of(
                         Map.of(
-                                "imageId", "3",
+                                "imageId", imageIds.get(0),
                                 "menu", Map.of(
                                         "name", "크림 파스타",
                                         "rating", 1
                                 )
                         ),
                         Map.of(
-                                "imageId", "4",
+                                "imageId", imageIds.get(1),
                                 "menu", Map.of(
                                         "name", "토마토 파스타",
                                         "rating", 2

--- a/be/src/test/java/com/foodymoody/be/acceptance/feed_collection/FeedCollectionAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/feed_collection/FeedCollectionAcceptanceTest.java
@@ -15,6 +15,7 @@ import static com.foodymoody.be.acceptance.feed_collection_comment.FeedCollectio
 import static com.foodymoody.be.acceptance.feed_collection_comment_like.FeedCollectionCommentLikeSteps.피드_컬렉션_댓글에_좋아요를_등록한다;
 import static com.foodymoody.be.acceptance.feed_collection_mood.FeedCollectionMoodSteps.피드_컬렉션_무드를_등록하고_아이디를_가져온다;
 import static com.foodymoody.be.acceptance.feed_collection_reply.FeedCollectionReplySteps.피드_컬렉션_댓글에_대댓글을_등록한다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
@@ -33,13 +34,19 @@ class FeedCollectionAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        List<String> imageIds = List.of(id1, id2);
+
         feedIds = new ArrayList<>();
         moodIds = new ArrayList<>();
-        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰));
-        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰));
-        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰));
-        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰));
-        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰));
+        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds));
+        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds));
+        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds));
+        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds));
+        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds));
         moodIds.add(피드_컬렉션_무드를_등록하고_아이디를_가져온다(회원아티_액세스토큰));
         moodIds.add(피드_컬렉션_무드를_등록하고_아이디를_가져온다(회원아티_액세스토큰));
         moodIds.add(피드_컬렉션_무드를_등록하고_아이디를_가져온다(회원아티_액세스토큰));

--- a/be/src/test/java/com/foodymoody/be/acceptance/feed_collection_comment/FeedCollectionCommentAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/feed_collection_comment/FeedCollectionCommentAcceptanceTest.java
@@ -6,6 +6,7 @@ import static com.foodymoody.be.acceptance.feed_collection_comment.FeedCollectio
 import static com.foodymoody.be.acceptance.feed_collection_comment.FeedCollectionCommentSteps.피드_컬렉션에_댓글을_등록한다;
 import static com.foodymoody.be.acceptance.feed_collection_comment.FeedCollectionCommentSteps.피드_컬렉션에_댓글을_삭제한다;
 import static com.foodymoody.be.acceptance.feed_collection_comment.FeedCollectionCommentSteps.피드_컬렉션에_댓글을_수정한다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
@@ -23,8 +24,14 @@ class FeedCollectionCommentAcceptanceTest extends AcceptanceTest {
     @DisplayName("피드를 등록하고 컬렉션을 생성한다.")
     @BeforeEach
     void setUp() {
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        List<String> imageIds = List.of(id1, id2);
+
         List<String> feedIds = new ArrayList<>();
-        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰));
+        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds));
         feedCollectionId = 피드_컬렉션_등록하고_아이디를_가져온다(feedIds, 회원아티_액세스토큰);
     }
 

--- a/be/src/test/java/com/foodymoody/be/acceptance/feed_collection_comment_like/FeedCollectionCommentLikeAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/feed_collection_comment_like/FeedCollectionCommentLikeAcceptanceTest.java
@@ -6,6 +6,7 @@ import static com.foodymoody.be.acceptance.feed_collection.FeedCollectionSteps.�
 import static com.foodymoody.be.acceptance.feed_collection_comment.FeedCollectionCommentSteps.피드_컬렉션에_댓글을_등록하고_아이디를_받는다;
 import static com.foodymoody.be.acceptance.feed_collection_comment_like.FeedCollectionCommentLikeSteps.피드_컬렉션_댓글에_좋아요를_등록한다;
 import static com.foodymoody.be.acceptance.feed_collection_comment_like.FeedCollectionCommentLikeSteps.피드_컬렉션_댓글에_좋아요를_취소한다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
@@ -23,8 +24,14 @@ class FeedCollectionCommentLikeAcceptanceTest extends AcceptanceTest {
     @DisplayName("피드 컬렉션 생성하고 댓글을 작성 한다")
     @BeforeEach
     void setUp() {
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        List<String> imageIds = List.of(id1, id2);
+
         List<String> feedIds = new ArrayList<>();
-        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰));
+        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds));
         String feedCollectionId = 피드_컬렉션_등록하고_아이디를_가져온다(feedIds, 회원아티_액세스토큰);
         commentId = 피드_컬렉션에_댓글을_등록하고_아이디를_받는다(회원아티_액세스토큰, feedCollectionId);
     }

--- a/be/src/test/java/com/foodymoody/be/acceptance/feed_collection_like/FeedCollectionLikeAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/feed_collection_like/FeedCollectionLikeAcceptanceTest.java
@@ -5,6 +5,7 @@ import static com.foodymoody.be.acceptance.feed_collection.FeedCollectionSteps.�
 import static com.foodymoody.be.acceptance.feed_collection_like.FeedCollectionLikeSteps.피드_컬렉션에_좋아요를_등록하고_아이디를_반환한다;
 import static com.foodymoody.be.acceptance.feed_collection_like.FeedCollectionLikeSteps.피드_컬렉션에_좋아요를_등록한다;
 import static com.foodymoody.be.acceptance.feed_collection_like.FeedCollectionLikeSteps.피드_컬렉션에_좋아요를_취소한다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
@@ -22,8 +23,14 @@ class FeedCollectionLikeAcceptanceTest extends AcceptanceTest {
     @DisplayName("피드를 등록하고 컬렉션을 생성한다.")
     @BeforeEach
     void setUp() {
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        List<String> imageIds = List.of(id1, id2);
+
         List<String> feedIds = new ArrayList<>();
-        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰));
+        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds));
         feedCollectionId = 피드_컬렉션_등록하고_아이디를_가져온다(feedIds, 회원아티_액세스토큰);
     }
 

--- a/be/src/test/java/com/foodymoody/be/acceptance/feed_collection_reply/FeedCollectionReplyAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/feed_collection_reply/FeedCollectionReplyAcceptanceTest.java
@@ -9,6 +9,7 @@ import static com.foodymoody.be.acceptance.feed_collection_reply.FeedCollectionR
 import static com.foodymoody.be.acceptance.feed_collection_reply.FeedCollectionReplySteps.피드_컬렉션_댓글의_대댓글을_수정한다;
 import static com.foodymoody.be.acceptance.feed_collection_reply.FeedCollectionReplySteps.피드_컬렉션_댓글의_대댓글을_조회한다;
 import static com.foodymoody.be.acceptance.feed_collection_reply_like.FeedCollectionReplyLikeSteps.피드_컬렉션_대댓글에_좋아요를_등록한다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
@@ -31,8 +32,14 @@ class FeedCollectionReplyAcceptanceTest extends AcceptanceTest {
     @DisplayName("피드 컬렉션 생성하고 댓글을 작성 한다")
     @BeforeEach
     void setUp() {
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        List<String> imageIds = List.of(id1, id2);
+
         List<String> feedIds = new ArrayList<>();
-        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰));
+        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds));
         String feedCollectionId = 피드_컬렉션_등록하고_아이디를_가져온다(feedIds, 회원아티_액세스토큰);
         commentId = 피드_컬렉션에_댓글을_등록하고_아이디를_받는다(회원아티_액세스토큰, feedCollectionId);
     }

--- a/be/src/test/java/com/foodymoody/be/acceptance/feed_collection_reply_like/FeedCollectionReplyLikeAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/feed_collection_reply_like/FeedCollectionReplyLikeAcceptanceTest.java
@@ -7,6 +7,7 @@ import static com.foodymoody.be.acceptance.feed_collection_reply.FeedCollectionR
 import static com.foodymoody.be.acceptance.feed_collection_reply_like.FeedCollectionReplyLikeSteps.피드_컬렉션_대댓글에_좋아요를_등록하고_아이디를_반환한다;
 import static com.foodymoody.be.acceptance.feed_collection_reply_like.FeedCollectionReplyLikeSteps.피드_컬렉션_대댓글에_좋아요를_등록한다;
 import static com.foodymoody.be.acceptance.feed_collection_reply_like.FeedCollectionReplyLikeSteps.피드_컬렉션_대댓글에_좋아요를_취소한다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
@@ -25,8 +26,14 @@ class FeedCollectionReplyLikeAcceptanceTest extends AcceptanceTest {
     @DisplayName("피드 컬렉션 대댓글을 생성하고 아이디를 반환한다.")
     @BeforeEach
     void setUp() {
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        List<String> imageIds = List.of(id1, id2);
+
         List<String> feedIds = new ArrayList<>();
-        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰));
+        feedIds.add(피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds));
         String feedCollectionId = 피드_컬렉션_등록하고_아이디를_가져온다(feedIds, 회원아티_액세스토큰);
         commentId = 피드_컬렉션에_댓글을_등록하고_아이디를_받는다(회원아티_액세스토큰, feedCollectionId);
         replyId = 피드_컬렉션_댓글에_대댓글을_등록하고_아이디를_반환한다(회원아티_액세스토큰, commentId);

--- a/be/src/test/java/com/foodymoody/be/acceptance/feed_heart/FeedHeartAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/feed_heart/FeedHeartAcceptanceTest.java
@@ -7,8 +7,11 @@ import static com.foodymoody.be.acceptance.feed_heart.FeedHeartSteps.좋아요_�
 import static com.foodymoody.be.acceptance.feed_heart.FeedHeartSteps.좋아요_한_적이_없는데_좋아요_취소를_한다;
 import static com.foodymoody.be.acceptance.feed_heart.FeedHeartSteps.좋아요된_피드에_또_좋아요를_한다;
 import static com.foodymoody.be.acceptance.feed_heart.FeedHeartSteps.좋아요를_한다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,7 +31,9 @@ class FeedHeartAcceptanceTest extends AcceptanceTest {
         api_문서_타이틀("like", spec);
 
         // given
-        String feedId = 피드를_등록한다(회원아티_액세스토큰, spec).jsonPath().getString("id");
+        List<String> imageIds = 피드_이미지_업로드_후_id_리스트를_반환한다();
+
+        String feedId = 피드를_등록한다(회원아티_액세스토큰, spec, imageIds).jsonPath().getString("id");
 
         // when
         var response = 좋아요를_한다(feedId, 회원아티_액세스토큰, spec);
@@ -45,7 +50,9 @@ class FeedHeartAcceptanceTest extends AcceptanceTest {
         api_문서_타이틀("likeFailed", spec);
 
         // given
-        String feedId = 피드를_등록한다(회원아티_액세스토큰, spec).jsonPath().getString("id");
+        List<String> imageIds = 피드_이미지_업로드_후_id_리스트를_반환한다();
+
+        String feedId = 피드를_등록한다(회원아티_액세스토큰, spec, imageIds).jsonPath().getString("id");
 
         // when
         좋아요를_한다(feedId, 회원아티_액세스토큰, spec);
@@ -61,7 +68,9 @@ class FeedHeartAcceptanceTest extends AcceptanceTest {
         api_문서_타이틀("unLike", spec);
 
         // given
-        String feedId = 피드를_등록한다(회원푸반_액세스토큰, spec).jsonPath().getString("id");
+        List<String> imageIds = 피드_이미지_업로드_후_id_리스트를_반환한다();
+
+        String feedId = 피드를_등록한다(회원푸반_액세스토큰, spec, imageIds).jsonPath().getString("id");
 
         // when
         좋아요를_한다(feedId, 회원푸반_액세스토큰, spec);
@@ -78,11 +87,22 @@ class FeedHeartAcceptanceTest extends AcceptanceTest {
         api_문서_타이틀("unLikeFailed", spec);
 
         // given
-        String feedId = 피드를_등록한다(회원푸반_액세스토큰, spec).jsonPath().getString("id");
+        List<String> imageIds = 피드_이미지_업로드_후_id_리스트를_반환한다();
+
+        String feedId = 피드를_등록한다(회원푸반_액세스토큰, spec, imageIds).jsonPath().getString("id");
 
         // when
         // then
         좋아요_한_적이_없는데_좋아요_취소를_한다(feedId, 회원푸반_액세스토큰, spec);
+    }
+
+    @NotNull
+    private List<String> 피드_이미지_업로드_후_id_리스트를_반환한다() {
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        return List.of(id1, id2);
     }
 
 }

--- a/be/src/test/java/com/foodymoody/be/acceptance/member/MemberAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/member/MemberAcceptanceTest.java
@@ -3,6 +3,7 @@ package com.foodymoody.be.acceptance.member;
 import static com.foodymoody.be.acceptance.auth.AuthSteps.로그인한다;
 import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_등록한다;
 import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_또_등록한다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 import static com.foodymoody.be.acceptance.image.ImageSteps.회원_이미지를_업로드한다;
 import static com.foodymoody.be.acceptance.member.MemberSteps.닉네임_중복_여부를_조회한다;
 import static com.foodymoody.be.acceptance.member.MemberSteps.로그인시_팔로워_목록을_조회한다;
@@ -148,9 +149,15 @@ class MemberAcceptanceTest extends AcceptanceTest {
             api_문서_타이틀("fetch_member_profile_if_not_login_success", spec);
 
             // given
-            피드를_등록한다(회원푸반_액세스토큰, new RequestSpecBuilder().build());
-            피드를_등록한다(회원푸반_액세스토큰, new RequestSpecBuilder().build());
-            피드를_등록한다(회원푸반_액세스토큰, new RequestSpecBuilder().build());
+            var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+            String id1 = imageResponse1.jsonPath().getString("id");
+            var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+            String id2 = imageResponse2.jsonPath().getString("id");
+            List<String> imageIds = List.of(id1, id2);
+
+            피드를_등록한다(회원푸반_액세스토큰, new RequestSpecBuilder().build(), imageIds);
+            피드를_등록한다(회원푸반_액세스토큰, new RequestSpecBuilder().build(), imageIds);
+            피드를_등록한다(회원푸반_액세스토큰, new RequestSpecBuilder().build(), imageIds);
 
             팔로우한다(회원아티_액세스토큰, 푸반_아이디, new RequestSpecBuilder().build());
 
@@ -221,9 +228,15 @@ class MemberAcceptanceTest extends AcceptanceTest {
             api_문서_타이틀("fetchMemberFeeds_success", spec);
 
             // given
+            var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+            String id1 = imageResponse1.jsonPath().getString("id");
+            var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+            String id2 = imageResponse2.jsonPath().getString("id");
+            List<String> imageIds = List.of(id1, id2);
+
             String 푸반_아이디 = jwtUtil.parseAccessToken(회원푸반_액세스토큰).get("id");
-            ExtractableResponse<Response> 첫번째_피드_등록_응답 = 피드를_등록한다(회원푸반_액세스토큰, new RequestSpecBuilder().build());
-            ExtractableResponse<Response> 두번째_피드_등록_응답 = 피드를_또_등록한다(회원푸반_액세스토큰, new RequestSpecBuilder().build());
+            ExtractableResponse<Response> 첫번째_피드_등록_응답 = 피드를_등록한다(회원푸반_액세스토큰, new RequestSpecBuilder().build(), imageIds);
+            ExtractableResponse<Response> 두번째_피드_등록_응답 = 피드를_또_등록한다(회원푸반_액세스토큰, new RequestSpecBuilder().build(), imageIds);
 
             // when
             var response = 피드목록을_조회한다(푸반_아이디, 0, 10, spec);
@@ -231,9 +244,9 @@ class MemberAcceptanceTest extends AcceptanceTest {
             // then
             List<Map<String, String>> expected = List.of(
                     Map.of("id", 두번째_피드_등록_응답.jsonPath().getString("id"),
-                            "imageUrl", "https://foodymoody-test.s3.ap-northeast-2.amazonaws.com/foodymoody_logo.png3"),
+                            "imageUrl", "https://s3Url/key"),
                     Map.of("id", 첫번째_피드_등록_응답.jsonPath().getString("id"),
-                            "imageUrl", "https://foodymoody-test.s3.ap-northeast-2.amazonaws.com/foodymoody_logo.png1")
+                            "imageUrl", "https://s3Url/key")
             );
             Assertions.assertAll(
                     () -> 상태코드를_검증한다(response, HttpStatus.OK),

--- a/be/src/test/java/com/foodymoody/be/acceptance/notification/FeedNotificationAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/notification/FeedNotificationAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.foodymoody.be.acceptance.notification;
 
 import static com.foodymoody.be.acceptance.comment.CommentSteps.피드에_댓글을_등록하고_아이디를_받는다;
 import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_등록하고_아이디를_받는다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 import static com.foodymoody.be.acceptance.notification.NotificationSteps.모든_알림을_읽음으로_변경한다;
 import static com.foodymoody.be.acceptance.notification.NotificationSteps.알림_아이디로_알림을_조회한다;
 import static com.foodymoody.be.acceptance.notification.NotificationSteps.알림을_삭제한다;
@@ -14,6 +15,7 @@ import static com.foodymoody.be.acceptance.notification.NotificationSteps.회원
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
 import com.foodymoody.be.auth.infra.JwtUtil;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -28,7 +30,13 @@ class FeedNotificationAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        var feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰);
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        List<String> imageIds = List.of(id1, id2);
+
+        var feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds);
         피드에_댓글을_등록하고_아이디를_받는다(feedId, 회원푸반_액세스토큰);
         피드에_댓글을_등록하고_아이디를_받는다(feedId, 회원푸반_액세스토큰);
         피드에_댓글을_등록하고_아이디를_받는다(feedId, 회원푸반_액세스토큰);

--- a/be/src/test/java/com/foodymoody/be/acceptance/reply/ReplyAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/reply/ReplyAcceptanceTest.java
@@ -4,10 +4,12 @@ import static com.foodymoody.be.acceptance.comment.CommentSteps.응답코드_200
 import static com.foodymoody.be.acceptance.comment.CommentSteps.응답코드_201을_반환한다;
 import static com.foodymoody.be.acceptance.comment.CommentSteps.피드에_댓글을_등록하고_아이디를_받는다;
 import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_등록하고_아이디를_받는다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 import static com.foodymoody.be.acceptance.reply.ReplySteps.댓글에_댓글을_등록한다;
 import static com.foodymoody.be.acceptance.reply.ReplySteps.댓글의_댓글을_조회한다;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,7 +22,13 @@ class ReplyAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰);
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        List<String> imageIds = List.of(id1, id2);
+
+        feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds);
         commentId = 피드에_댓글을_등록하고_아이디를_받는다(feedId, 회원아티_액세스토큰);
 
     }

--- a/be/src/test/java/com/foodymoody/be/acceptance/reply_heart/ReplyFeedHeartAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/reply_heart/ReplyFeedHeartAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.foodymoody.be.acceptance.reply_heart;
 
 import static com.foodymoody.be.acceptance.comment.CommentSteps.피드에_댓글을_등록하고_아이디를_받는다;
 import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_등록하고_아이디를_받는다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 import static com.foodymoody.be.acceptance.reply.ReplySteps.댓글에_댓글을_등록한다;
 import static com.foodymoody.be.acceptance.reply.ReplySteps.댓글의_댓글을_조회한다;
 import static com.foodymoody.be.acceptance.reply_heart.ReplyHeartSteps.좋아요를_누린다;
@@ -9,6 +10,7 @@ import static com.foodymoody.be.acceptance.reply_heart.ReplyHeartSteps.좋아요
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,7 +24,13 @@ class ReplyFeedHeartAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        feedId = 피드를_등록하고_아이디를_받는다(회원푸반_액세스토큰);
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        List<String> imageIds = List.of(id1, id2);
+
+        feedId = 피드를_등록하고_아이디를_받는다(회원푸반_액세스토큰, imageIds);
         commentId = 피드에_댓글을_등록하고_아이디를_받는다(feedId, 회원아티_액세스토큰);
         댓글에_댓글을_등록한다(feedId, commentId, 회원푸반_액세스토큰);
         firstReplyId = 댓글의_댓글을_조회한다(commentId).jsonPath().getList("content.id", String.class).get(0);

--- a/be/src/test/java/com/foodymoody/be/acceptance/sse/SseAcceptanceTest.java
+++ b/be/src/test/java/com/foodymoody/be/acceptance/sse/SseAcceptanceTest.java
@@ -2,10 +2,12 @@ package com.foodymoody.be.acceptance.sse;
 
 import static com.foodymoody.be.acceptance.comment.CommentSteps.피드에_댓글을_등록하고_아이디를_받는다;
 import static com.foodymoody.be.acceptance.feed.FeedSteps.피드를_등록하고_아이디를_받는다;
+import static com.foodymoody.be.acceptance.image.ImageSteps.피드_이미지를_업로드한다;
 import static com.foodymoody.be.acceptance.sse.SseSteps.sse_연결_요청;
 import static com.foodymoody.be.acceptance.sse.SseSteps.응답코드가_200;
 
 import com.foodymoody.be.acceptance.AcceptanceTest;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,7 +17,13 @@ class SseAcceptanceTest extends AcceptanceTest {
 
     @BeforeEach
     void setUp() {
-        var feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰);
+        var imageResponse1 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id1 = imageResponse1.jsonPath().getString("id");
+        var imageResponse2 = 피드_이미지를_업로드한다(회원아티_액세스토큰, spec);
+        String id2 = imageResponse2.jsonPath().getString("id");
+        List<String> imageIds = List.of(id1, id2);
+
+        var feedId = 피드를_등록하고_아이디를_받는다(회원아티_액세스토큰, imageIds);
         피드에_댓글을_등록하고_아이디를_받는다(feedId, 회원푸반_액세스토큰);
         피드에_댓글을_등록하고_아이디를_받는다(feedId, 회원푸반_액세스토큰);
         피드에_댓글을_등록하고_아이디를_받는다(feedId, 회원푸반_액세스토큰);


### PR DESCRIPTION
## Key changes🔧
- 
## To reviewer👋
- 이미지 테스트 방법을 직접 이미지를 생성하는 것으로 변경하였습니다.
  - 그 과정에서 피드를 등록할 때 필수적으로 이미지를 등록해야 하는 절차가 생겼습니다. 
