### PR TITLE
[FE] refresh토큰을 통한 액세스토큰 재발급, sse 재연결

### DIFF
--- a/fe/src/components/common/icon/NotiIcon.tsx
+++ b/fe/src/components/common/icon/NotiIcon.tsx
@@ -63,6 +63,7 @@ export const NotiIcon: React.FC<Props> = ({ onClick }) => {
             setRefreshToken(refreshToken);
             setUserInfo(JSON.stringify(payload));
             setAuthToken(accessToken);
+            return;
           } catch (error) {
             clearLoginInfo();
             return;

--- a/fe/src/components/common/icon/NotiIcon.tsx
+++ b/fe/src/components/common/icon/NotiIcon.tsx
@@ -30,7 +30,6 @@ export const NotiIcon: React.FC<Props> = ({ onClick }) => {
 
       if (token !== currentToken) {
         setCurrentToken(token);
-        // 토큰 변경에 따른 추가적인 로직
       }
 
       const eventSource = new EventSourcePolyfill(`${BASE_API_URL}/sse`, {

--- a/fe/src/components/common/icon/NotiIcon.tsx
+++ b/fe/src/components/common/icon/NotiIcon.tsx
@@ -21,21 +21,21 @@ type Props = {
 
 export const NotiIcon: React.FC<Props> = ({ onClick }) => {
   const [notiCount, setNotiCount] = useState(0);
-  const [currentToken, setCurrentToken] = useState<string | null>(null);
+  const [authToken, setAuthToken] = useState<string | null>(null);
 
   const { isLogin } = useAuthState();
   useEffect(() => {
     if (isLogin) {
-      const token = getAccessToken();
+      const currentToken = getAccessToken();
 
-      if (token !== currentToken) {
-        setCurrentToken(token);
+      if (currentToken !== authToken) {
+        setAuthToken(currentToken);
       }
 
       const eventSource = new EventSourcePolyfill(`${BASE_API_URL}/sse`, {
         headers: {
           'Content-Type': 'text/event-stream',
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${currentToken}`,
         },
       });
 
@@ -62,7 +62,7 @@ export const NotiIcon: React.FC<Props> = ({ onClick }) => {
             setAccessToken(accessToken);
             setRefreshToken(refreshToken);
             setUserInfo(JSON.stringify(payload));
-            setCurrentToken(accessToken);
+            setAuthToken(accessToken);
           } catch (error) {
             clearLoginInfo();
             return;
@@ -74,7 +74,7 @@ export const NotiIcon: React.FC<Props> = ({ onClick }) => {
         eventSource.close();
       };
     }
-  }, [isLogin, notiCount, currentToken]);
+  }, [isLogin, notiCount, authToken]);
 
   return (
     <Wrapper>

--- a/fe/src/components/feedEditor/FeedEditor.tsx
+++ b/fe/src/components/feedEditor/FeedEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { useToggle } from 'recoil/booleanState/useToggle';
 import { useFeedDetail, useFeedEditor } from 'service/queries/feed';
 import { styled } from 'styled-components';
 import { customScrollStyle, flexColumn, flexRow } from 'styles/customStyle';
@@ -16,11 +17,12 @@ import { useMenuItem } from 'hooks/useMenuItem';
 import { usePageNavigator } from 'hooks/usePageNavigator';
 
 export const FeedEditor: React.FC = () => {
+  const search = useToggle('search');
   const { navigateToHome } = usePageNavigator();
   const [selectedBadgeList, setSelectedBadgeList] = useState<Badge[]>([]);
 
   const { id: feedId } = useParams() as { id: string };
-  const { mutate: feedMutate } = useFeedEditor(feedId);
+  const { mutate: feedMutate, status } = useFeedEditor(feedId);
   const { data: feedDetailData } = useFeedDetail(feedId);
   const {
     menuItems,
@@ -64,6 +66,7 @@ export const FeedEditor: React.FC = () => {
       storeMood: selectedBadgeList.map((badge) => badge.id),
       review: reviewValue,
     });
+    status === 'success' && search.toggleOn();
   };
 
   const handleSelectBadgeList = (badges: Badge[]) => {
@@ -80,6 +83,7 @@ export const FeedEditor: React.FC = () => {
     menuItems
       .map((menuItem) => menuItem.menu.name)
       .every((name) => name.trim().length > 0);
+  console.log(locationName, 'isValid');
 
   return (
     <Wrapper>

--- a/fe/src/components/notification/NotiList.tsx
+++ b/fe/src/components/notification/NotiList.tsx
@@ -35,7 +35,7 @@ export const NotiList = () => {
         return (
           <NotiItem
             notification={notification}
-            key={notification.notificationId}
+            // key={notification.notificationId}
             ref={isLastItem ? observeTarget : null}
             onClick={handleNotificationClick}
           />

--- a/fe/src/components/searchLocation/SearchLocation.tsx
+++ b/fe/src/components/searchLocation/SearchLocation.tsx
@@ -24,6 +24,8 @@ export const SearchLocation: React.FC<Props> = ({
   const [searchResult, setSearchResult] = useState([]);
   const search = useToggle('search');
   const tool = useToggle('tool');
+  console.log(search.isTrue, 'search istrue');
+  console.log(tool.isTrue, 'search istrue');
 
   const [selectedLocation, setSelectedLocation] = useState({
     id: '',
@@ -71,6 +73,7 @@ export const SearchLocation: React.FC<Props> = ({
       category_name: location.category_name,
       category_group_code: location.category_group_code,
     });
+    handleLocationChange(location.place_name);
   };
 
   const handleSearchLocation = (locationName: string) => {
@@ -89,7 +92,7 @@ export const SearchLocation: React.FC<Props> = ({
     });
   };
 
-  const placesSearchCB = (data, status) => {
+  const placesSearchCB = (data: any, status: any) => {
     if (status === window.kakao.maps.services.Status.OK) {
       console.log(data, 'kakao search data');
       setSearchResult(data);

--- a/fe/src/components/searchPanelInput/SearchPanelInput.tsx
+++ b/fe/src/components/searchPanelInput/SearchPanelInput.tsx
@@ -26,24 +26,28 @@ export const SearchPanelInput: React.FC<Props> = ({
   // TODO panel 데이터 페치
   const search = useToggle('search');
 
-  const handlePanelClose = () => {
-    onChangeValue?.('');
-  };
+  // const handlePanelClose = () => {
+  //   onChangeValue?.('');
+  // };
 
   return (
     <Wrapper>
       <Input variant={variant} helperText={helperText}>
         <Input.CenterContent>
-          <InputField value={value} onChangeValue={onChangeValue} />
+          <InputField
+            value={value}
+            onChangeValue={onChangeValue}
+            onClick={search.toggleOn}
+          />
         </Input.CenterContent>
-        <Input.BottomPanel isOpen={value?.trim().length !== 0}>
+        <Input.BottomPanel isOpen={search.isTrue && value?.trim().length !== 0}>
           {data.map((result) => (
             <ItemRow
               key={result.id}
               onClick={() => {
                 console.log(result, 'result');
                 onSelectLocation(result);
-                handlePanelClose();
+                // handlePanelClose();
                 search.toggleOff();
               }}
             >

--- a/fe/src/pages/NewFeedPage.tsx
+++ b/fe/src/pages/NewFeedPage.tsx
@@ -1,4 +1,5 @@
 import { Navigate, useLocation } from 'react-router-dom';
+import { useToggle } from 'recoil/booleanState/useToggle';
 import { styled } from 'styled-components';
 import { media } from 'styles/mediaQuery';
 import { Dim } from 'components/common/dim/Dim';
@@ -11,10 +12,16 @@ export const NewFeedModalPage = () => {
   const currentPath = useLocation();
   const { isLogin } = useAuthState();
   const { navigateToHome } = usePageNavigator();
+  const search = useToggle('search');
 
   return isLogin ? (
     <>
-      <Dim onClick={navigateToHome} />
+      <Dim
+        onClick={() => {
+          navigateToHome();
+          search.toggleOn();
+        }}
+      />
       <Wrapper>
         <FeedEditor />
       </Wrapper>

--- a/fe/src/service/axios/fetcher.ts
+++ b/fe/src/service/axios/fetcher.ts
@@ -1,4 +1,15 @@
 import axios from 'axios';
+import { jwtDecode } from 'jwt-decode';
+import { useNavigate } from 'react-router-dom';
+import {
+  clearLoginInfo,
+  getRefreshToken,
+  setAccessToken,
+  setRefreshToken,
+  setUserInfo,
+} from 'utils/localStorage';
+import { fetchRefresh } from './auth/login';
+import { PATH } from 'constants/path';
 
 const { MODE, VITE_API_URL } = import.meta.env;
 
@@ -44,10 +55,34 @@ privateApi.interceptors.request.use(
 privateApi.interceptors.response.use(
   (response) => response,
   async (error) => {
-    console.log(error.response.status, '페쳐 error.response.status');
     console.log(error.response, '페쳐 error.response');
+    if (error.response.status === 401) {
+      const token = getRefreshToken();
+      if (!token) {
+        return Promise.reject(error);
+      }
 
+      const { accessToken, refreshToken } = await fetchRefresh(token);
+      const payload = jwtDecode(accessToken);
+
+      setAccessToken(accessToken);
+      setRefreshToken(refreshToken);
+      setUserInfo(JSON.stringify(payload));
+      console.log('리프레시 토큰 다시받아서 요청 보낼거임');
+
+      error.config.headers['Authorization'] = `Bearer ${accessToken}`;
+      return privateApi.request(error.config);
+    } else if (error.response.data.code === 'a002') {
+      console.log('리프레시 토큰 만료~~ 에러 ');
+      //리프레쉬토큰 만료
+      clearLoginInfo();
+
+      const navigate = useNavigate();
+      navigate(PATH.HOME, { replace: true });
+    }
     // TODO 리프레시 토큰 및 에러
+    // 에러바운더리 캐치
+    console.log('그냥 에러 에러바운더리 ');
 
     return Promise.reject(error);
   }

--- a/fe/src/service/axios/fetcher.ts
+++ b/fe/src/service/axios/fetcher.ts
@@ -58,10 +58,7 @@ privateApi.interceptors.response.use(
     if (error.response.status === 401) {
       const token = getRefreshToken();
       if (!token) {
-        // TODO 에러바운더리 처리
         clearLoginInfo();
-        // const navigate = useNavigate();
-        // navigate(PATH.HOME, { replace: true });
         return;
       }
 
@@ -72,16 +69,11 @@ privateApi.interceptors.response.use(
         setAccessToken(accessToken);
         setRefreshToken(refreshToken);
         setUserInfo(JSON.stringify(payload));
-        console.log('리프레시 토큰 다시받아서 요청 보낼거임');
 
         error.config.headers['Authorization'] = `Bearer ${accessToken}`;
         return privateApi.request(error.config);
       } catch (error) {
-        console.log(error, '리프레시 토큰 만료~~ 에러 ');
-        //리프레쉬토큰 만료
         clearLoginInfo();
-        // const navigate = useNavigate();
-        // navigate(PATH.HOME, { replace: true });
         return;
       }
     }

--- a/fe/src/service/constants/endpoint.ts
+++ b/fe/src/service/constants/endpoint.ts
@@ -1,7 +1,7 @@
 export const END_POINT = {
   login: `/auth/login`,
   logout: `/auth/logout`,
-  refresh: `/auth/refresh`, // 수정가능성
+  refresh: `/auth/token`, // 수정가능성
   tasteMood: `/members/taste-moods`,
   storeMood: `/feeds/store-moods`,
   collection: (id?: string) => (id ? `/collections/${id}` : `/collections`),


### PR DESCRIPTION
## Key changes🔧
- refresh토큰을 통한 accessToken 재발급 기능을 추가했습니다
- NotiIcon.tsx 내부에 sse 재연결 로직을 추가했습니다
  - 어떤 문제인지 여전히 cors랑 502 에러가 간헐적으로 터집니다 
  - 그러나 sse연결 자체가 끊기진 않아요 cors, 502가 있어도 이벤트를 받을 수 있습니다  
     -    안정화됨 

## To reviewer👋
- feedEditor 패널 open로직을 살짝 수정했습니다
  - feed는 location데이터와 연동이 돼야하므로 추가 수정 예정입니다 원래 이 pr에 포함되면 안되는데..
  - 현재 feed 등록이 안됩니다 id가 필요하다는 에러가 반환되는데 아마 api 명세가 바뀐 듯 하네요