### PR TITLE
[FE] onError 캐치후 재발급 -> 토큰만료되면 바로 재발급

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -1,15 +1,14 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { RouterProvider } from 'react-router-dom';
+import { RouteContainer } from 'RouteContainer';
+// import { RouterProvider } from 'react-router-dom';
 import { RecoilRoot, RecoilEnv } from 'recoil';
 import { ThemeProvider } from 'styled-components';
-import router from 'routes/router';
+// import router from 'routes/router';
 import { theme } from 'styles/designSystem';
 import { GlobalStyles } from 'styles/globalStyles.ts';
 import { GlobalModals } from 'components/common/modal/Modal';
 import { GlobalToasts } from 'components/common/toast/Toast';
-
-// import { useRefreshToken } from 'hooks/auth/useAuth';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -22,7 +21,6 @@ const queryClient = new QueryClient({
 
 function App() {
   RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
-  // useRefreshToken();
 
   return (
     <>
@@ -33,7 +31,8 @@ function App() {
             <GlobalStyles />
             <GlobalModals />
             <GlobalToasts />
-            <RouterProvider router={router} />
+            {/* <RouterProvider router={router} /> */}
+            <RouteContainer />
           </RecoilRoot>
         </ThemeProvider>
       </QueryClientProvider>

--- a/fe/src/RouteContainer.tsx
+++ b/fe/src/RouteContainer.tsx
@@ -1,0 +1,8 @@
+import { RouterProvider } from 'react-router-dom';
+import { useRefreshToken } from 'service/queries/auth';
+import router from 'routes/router';
+
+export const RouteContainer = () => {
+  useRefreshToken();
+  return <RouterProvider router={router} />;
+};

--- a/fe/src/components/common/help/ServiceNotOpen.tsx
+++ b/fe/src/components/common/help/ServiceNotOpen.tsx
@@ -1,0 +1,75 @@
+import { styled } from 'styled-components';
+import { flexColumn } from 'styles/customStyle';
+import { usePageNavigator } from 'hooks/usePageNavigator';
+import { Button } from '../button/Button';
+
+export const ServiceNotOpen = () => {
+  const { navigateToHome } = usePageNavigator();
+
+  const handleNavigateToHome = () => {
+    navigateToHome();
+  };
+  const handleNavigateToGithub = () => {
+    window.open('https://github.com/foody-moody/foodymoody', '_blank');
+  };
+
+  return (
+    <Wrapper>
+      <FlexColumn>
+        <Text>서비스 준비중입니다.</Text>
+        <SubText>푸디무디를 기대해 주세요!</SubText>
+      </FlexColumn>
+
+      <FlexColumn>
+        <Button
+          size="s"
+          backgroundColor="orange"
+          shadow
+          width={250}
+          onClick={handleNavigateToHome}
+        >
+          홈으로
+        </Button>
+        <Button
+          size="s"
+          backgroundColor="black"
+          shadow
+          width={250}
+          onClick={handleNavigateToGithub}
+        >
+          깃허브 둘러보기
+        </Button>
+      </FlexColumn>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  width: 300px;
+  height: 300px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 36px;
+  border-radius: 4px;
+  border: 1px solid ${({ theme: { colors } }) => colors.black};
+  background: ${({ theme: { colors } }) => colors.white};
+`;
+
+const FlexColumn = styled.div`
+  ${flexColumn}
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+`;
+
+const Text = styled.p`
+  font: ${({ theme: { fonts } }) => fonts.displayB16};
+  color: ${({ theme: { colors } }) => colors.black};
+`;
+
+const SubText = styled.p`
+  font: ${({ theme: { fonts } }) => fonts.displayM14};
+  color: ${({ theme: { colors } }) => colors.textSecondary};
+`;

--- a/fe/src/components/common/icon/NotiIcon.tsx
+++ b/fe/src/components/common/icon/NotiIcon.tsx
@@ -34,6 +34,13 @@ export const NotiIcon: React.FC<Props> = ({ onClick }) => {
         }
       });
 
+      eventSource.onerror = (err) => {
+        if (eventSource.readyState === EventSource.CLOSED) {
+          console.log(err, 'SSE closed');
+          // 오류 날릴지 여부
+        }
+      };
+
       return () => {
         eventSource.close();
       };

--- a/fe/src/components/common/icon/NotiIcon.tsx
+++ b/fe/src/components/common/icon/NotiIcon.tsx
@@ -28,10 +28,6 @@ export const NotiIcon: React.FC<Props> = ({ onClick }) => {
     if (isLogin) {
       const currentToken = getAccessToken();
 
-      if (currentToken !== authToken) {
-        setAuthToken(currentToken);
-      }
-
       const eventSource = new EventSourcePolyfill(`${BASE_API_URL}/sse`, {
         headers: {
           'Content-Type': 'text/event-stream',
@@ -62,7 +58,9 @@ export const NotiIcon: React.FC<Props> = ({ onClick }) => {
             setAccessToken(accessToken);
             setRefreshToken(refreshToken);
             setUserInfo(JSON.stringify(payload));
-            setAuthToken(accessToken);
+            if (accessToken !== authToken) {
+              setAuthToken(accessToken);
+            }
             return;
           } catch (error) {
             clearLoginInfo();
@@ -75,7 +73,7 @@ export const NotiIcon: React.FC<Props> = ({ onClick }) => {
         eventSource.close();
       };
     }
-  }, [isLogin, notiCount, authToken]);
+  }, [isLogin, authToken]);
 
   return (
     <Wrapper>

--- a/fe/src/components/common/icon/NotiIcon.tsx
+++ b/fe/src/components/common/icon/NotiIcon.tsx
@@ -1,20 +1,10 @@
 import { EventSourcePolyfill } from 'event-source-polyfill';
-import { jwtDecode } from 'jwt-decode';
 import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { accessTokenState } from 'recoil/localStorage/atom';
-import { fetchRefresh } from 'service/axios/auth/login';
 import { BASE_API_URL } from 'service/axios/fetcher';
 import { styled } from 'styled-components';
 import { useAuthState } from 'hooks/auth/useAuth';
-import {
-  clearLoginInfo,
-  getAccessToken,
-  getRefreshToken,
-  setAccessToken,
-  setRefreshToken,
-  setUserInfo,
-} from 'utils/localStorage';
 import { NotificationIcon } from './icons';
 
 type Props = {
@@ -23,14 +13,8 @@ type Props = {
 
 export const NotiIcon: React.FC<Props> = ({ onClick }) => {
   const [notiCount, setNotiCount] = useState(0);
-
   const { isLogin } = useAuthState();
-  // const currentToken = getAccessToken();
-  // 여기 리코일로   const [authToken, setAuthToken] = useState<string | null>(null); 이거 바꿔서 디펜던시에 authToken넣어주고 되나 보기
   const accessToken = useRecoilValue(accessTokenState);
-  console.log(accessToken, ' now accessToken');
-  const token = localStorage.getItem('accessToken');
-  console.log(token, ' now tokentokenaccessToken');
 
   useEffect(() => {
     if (isLogin) {

--- a/fe/src/hooks/auth/useAuth.ts
+++ b/fe/src/hooks/auth/useAuth.ts
@@ -27,46 +27,6 @@ export const useAuthState = () => {
   return { isLogin, userInfo };
 };
 
-export const useRefreshToken = () => {
-  useEffect(() => {
-    const refreshToken = getRefreshToken();
-
-    if (!refreshToken) return;
-
-    const getAccessTokenByRefreshToken = async () => {
-      try {
-        // const { accessToken, refreshToken } = await //Token 요청;
-        // setAccessToken(accessToken);
-        // setRefreshToken(refreshToken);
-      } catch (error) {
-        console.error('Error during fetching access token:', error);
-        // 로그아웃
-        clearLoginInfo();
-      }
-    };
-
-    getAccessTokenByRefreshToken();
-  }, []);
-};
-
-// export const useLogout = () => {
-//   // const setIsLogin = useSetRecoilState(isLoginState);
-//   const { navigateToHome } = usePageNavigator();
-
-//   const handleLogout = async () => {
-//     try {
-//       await fetchLogout();
-//       clearLoginInfo();
-//       // setIsLogin(false);
-//       navigateToHome();
-//     } catch (error) {
-//       console.error('Logout error:', error);
-//     }
-//   };
-
-//   return { handleLogout };
-// };
-
 export const useUnRegister = () => {
   const { navigateToHome } = usePageNavigator();
 

--- a/fe/src/pages/SearchPage.tsx
+++ b/fe/src/pages/SearchPage.tsx
@@ -1,3 +1,20 @@
+import { styled } from 'styled-components';
+import { ServiceNotOpen } from 'components/common/help/ServiceNotOpen';
+
 export const SearchPage = () => {
-  return <div>SearchPage</div>;
+  return (
+    <Wrapper>
+      <ServiceNotOpen />
+    </Wrapper>
+  );
 };
+
+const Wrapper = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100dvh;
+  position: relative;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;

--- a/fe/src/recoil/localStorage/atom.ts
+++ b/fe/src/recoil/localStorage/atom.ts
@@ -4,18 +4,24 @@ export const localStorageEffect: <T>(key: string) => AtomEffect<T> =
   (key: string) =>
   ({ setSelf, onSet }) => {
     const savedValue = localStorage.getItem(key);
+    console.log(savedValue, 'savedValue!!!!!!!!!!!!!!!!!');
 
     if (savedValue != null) {
+      console.log(savedValue, 'not null savedValue!!!!!!!!!!!!!!!!!');
       if (key === 'userInfo') {
-        return setSelf(JSON.parse(savedValue));
+        console.log(JSON.parse(savedValue), 'this is Userinfo');
+
+        return setSelf(savedValue);
       } else {
+        console.log(savedValue, 'this is not Userinfo');
+
         return setSelf(savedValue);
       }
     }
 
     onSet((newValue) => {
       if (newValue != null) {
-        return localStorage.setItem(key, newValue);
+        return localStorage.setItem(key, newValue as string);
       } else {
         localStorage.removeItem(key);
       }

--- a/fe/src/recoil/localStorage/atom.ts
+++ b/fe/src/recoil/localStorage/atom.ts
@@ -4,44 +4,38 @@ export const localStorageEffect: <T>(key: string) => AtomEffect<T> =
   (key: string) =>
   ({ setSelf, onSet }) => {
     const savedValue = localStorage.getItem(key);
-    console.log(savedValue, 'savedValue!!!!!!!!!!!!!!!!!');
 
     if (savedValue != null) {
-      console.log(savedValue, 'not null savedValue!!!!!!!!!!!!!!!!!');
-      if (key === 'userInfo') {
-        console.log(JSON.parse(savedValue), 'this is Userinfo');
-
-        return setSelf(savedValue);
-      } else {
-        console.log(savedValue, 'this is not Userinfo');
-
-        return setSelf(savedValue);
-      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return setSelf(savedValue as any); //string
+    } else {
+      localStorage.removeItem(key);
     }
 
     onSet((newValue) => {
       if (newValue != null) {
-        return localStorage.setItem(key, newValue as string);
+        // return localStorage.setItem(key, newValue as string);
+        localStorage.setItem(key, newValue as string);
       } else {
         localStorage.removeItem(key);
       }
     });
   };
 
-export const accessTokenState = atom<string | null>({
+export const accessTokenState = atom<string>({
   key: 'accessTokenState',
-  default: null,
+  default: '',
   effects: [localStorageEffect('accessToken')],
 });
 
-export const refreshTokenState = atom<string | null>({
+export const refreshTokenState = atom<string>({
   key: 'refreshTokenState',
-  default: null,
+  default: '',
   effects: [localStorageEffect('refreshToken')],
 });
 
-export const userInfoState = atom<string | null>({
+export const userInfoState = atom<string>({
   key: 'userInfoState',
-  default: null,
+  default: '',
   effects: [localStorageEffect('userInfo')],
 });

--- a/fe/src/recoil/localStorage/atom.ts
+++ b/fe/src/recoil/localStorage/atom.ts
@@ -1,0 +1,41 @@
+import { AtomEffect, atom } from 'recoil';
+
+export const localStorageEffect: <T>(key: string) => AtomEffect<T> =
+  (key: string) =>
+  ({ setSelf, onSet }) => {
+    const savedValue = localStorage.getItem(key);
+
+    if (savedValue != null) {
+      if (key === 'userInfo') {
+        return setSelf(JSON.parse(savedValue));
+      } else {
+        return setSelf(savedValue);
+      }
+    }
+
+    onSet((newValue) => {
+      if (newValue != null) {
+        return localStorage.setItem(key, newValue);
+      } else {
+        localStorage.removeItem(key);
+      }
+    });
+  };
+
+export const accessTokenState = atom<string | null>({
+  key: 'accessTokenState',
+  default: null,
+  effects: [localStorageEffect('accessToken')],
+});
+
+export const refreshTokenState = atom<string | null>({
+  key: 'refreshTokenState',
+  default: null,
+  effects: [localStorageEffect('refreshToken')],
+});
+
+export const userInfoState = atom<string | null>({
+  key: 'userInfoState',
+  default: null,
+  effects: [localStorageEffect('userInfo')],
+});

--- a/fe/src/recoil/localStorage/atom.ts
+++ b/fe/src/recoil/localStorage/atom.ts
@@ -8,34 +8,35 @@ export const localStorageEffect: <T>(key: string) => AtomEffect<T> =
     if (savedValue != null) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       return setSelf(savedValue as any); //string
-    } else {
-      localStorage.removeItem(key);
     }
 
-    onSet((newValue) => {
-      if (newValue != null) {
-        // return localStorage.setItem(key, newValue as string);
-        localStorage.setItem(key, newValue as string);
-      } else {
-        localStorage.removeItem(key);
-      }
+    onSet((newValue, _, isReset) => {
+      // if (newValue != null) {
+      //   // return localStorage.setItem(key, newValue as string);
+      //   localStorage.setItem(key, newValue as string);
+      // } else {
+      //   localStorage.removeItem(key);
+      // }
+      isReset
+        ? localStorage.removeItem(key)
+        : localStorage.setItem(key, newValue as string);
     });
   };
 
 export const accessTokenState = atom<string>({
   key: 'accessTokenState',
-  default: '',
+  default: localStorage.getItem('accessToken') || '',
   effects: [localStorageEffect('accessToken')],
 });
 
 export const refreshTokenState = atom<string>({
   key: 'refreshTokenState',
-  default: '',
+  default: localStorage.getItem('refreshToken') || '',
   effects: [localStorageEffect('refreshToken')],
 });
 
 export const userInfoState = atom<string>({
   key: 'userInfoState',
-  default: '',
+  default: localStorage.getItem('userInfo') || '',
   effects: [localStorageEffect('userInfo')],
 });

--- a/fe/src/service/axios/fetcher.ts
+++ b/fe/src/service/axios/fetcher.ts
@@ -1,16 +1,5 @@
 import axios from 'axios';
-import { jwtDecode } from 'jwt-decode';
-import { useRecoilValue } from 'recoil';
-import { accessTokenState } from 'recoil/localStorage/atom';
-import {
-  clearLoginInfo,
-  getAccessToken,
-  getRefreshToken,
-  setAccessToken,
-  setRefreshToken,
-  setUserInfo,
-} from 'utils/localStorage';
-import { fetchRefresh } from './auth/login';
+import { getAccessToken } from 'utils/localStorage';
 
 const { MODE, VITE_API_URL } = import.meta.env;
 
@@ -37,15 +26,10 @@ export const multiFormApi = axios.create({
     'Content-Type': 'multipart/form-data',
   },
 });
-// 토큰 만료시간을 확인한다
-// 토큰 만료시간 직전이거나 만료시간이 지났을때, 토큰을 재발급 받는다
 
 privateApi.interceptors.request.use(
   (config) => {
-    // const accessToken = useRecoilValue(accessTokenState);
-    // const token = localStorage.getItem('accessToken');
     const token = getAccessToken();
-    console.log(token, '토큰!!!!!!!!!!!!!!!!!!!!');
 
     if (token) {
       config.headers['Authorization'] = `Bearer ${token}`;
@@ -63,29 +47,6 @@ privateApi.interceptors.response.use(
   async (error) => {
     console.log(error.response, '페쳐 error.response');
 
-    // if (error.response.status === 401) {
-    //   const token = getRefreshToken();
-    //   if (!token) {
-    //     clearLoginInfo();
-    //     return;
-    //   }
-
-    //   try {
-    //     const { accessToken, refreshToken } = await fetchRefresh(token);
-    //     const payload = jwtDecode(accessToken);
-    //     // TODO 백에서 refresh에 변동이 있을수있음
-    //     setAccessToken(accessToken);
-    //     setRefreshToken(refreshToken);
-    //     setUserInfo(JSON.stringify(payload));
-
-    //     error.config.headers['Authorization'] = `Bearer ${accessToken}`;
-    //     return privateApi.request(error.config);
-    //   } catch (error) {
-    //     clearLoginInfo();
-    //     return;
-    //   }
-    // }
-    // 에러처리
     return Promise.reject(error);
   }
 );

--- a/fe/src/service/axios/fetcher.ts
+++ b/fe/src/service/axios/fetcher.ts
@@ -1,7 +1,10 @@
 import axios from 'axios';
 import { jwtDecode } from 'jwt-decode';
+import { useRecoilValue } from 'recoil';
+import { accessTokenState } from 'recoil/localStorage/atom';
 import {
   clearLoginInfo,
+  getAccessToken,
   getRefreshToken,
   setAccessToken,
   setRefreshToken,
@@ -34,10 +37,15 @@ export const multiFormApi = axios.create({
     'Content-Type': 'multipart/form-data',
   },
 });
+// 토큰 만료시간을 확인한다
+// 토큰 만료시간 직전이거나 만료시간이 지났을때, 토큰을 재발급 받는다
 
 privateApi.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('accessToken');
+    // const accessToken = useRecoilValue(accessTokenState);
+    // const token = localStorage.getItem('accessToken');
+    const token = getAccessToken();
+    console.log(token, '토큰!!!!!!!!!!!!!!!!!!!!');
 
     if (token) {
       config.headers['Authorization'] = `Bearer ${token}`;
@@ -55,28 +63,28 @@ privateApi.interceptors.response.use(
   async (error) => {
     console.log(error.response, '페쳐 error.response');
 
-    if (error.response.status === 401) {
-      const token = getRefreshToken();
-      if (!token) {
-        clearLoginInfo();
-        return;
-      }
+    // if (error.response.status === 401) {
+    //   const token = getRefreshToken();
+    //   if (!token) {
+    //     clearLoginInfo();
+    //     return;
+    //   }
 
-      try {
-        const { accessToken, refreshToken } = await fetchRefresh(token);
-        const payload = jwtDecode(accessToken);
-        // TODO 백에서 refresh에 변동이 있을수있음
-        setAccessToken(accessToken);
-        setRefreshToken(refreshToken);
-        setUserInfo(JSON.stringify(payload));
+    //   try {
+    //     const { accessToken, refreshToken } = await fetchRefresh(token);
+    //     const payload = jwtDecode(accessToken);
+    //     // TODO 백에서 refresh에 변동이 있을수있음
+    //     setAccessToken(accessToken);
+    //     setRefreshToken(refreshToken);
+    //     setUserInfo(JSON.stringify(payload));
 
-        error.config.headers['Authorization'] = `Bearer ${accessToken}`;
-        return privateApi.request(error.config);
-      } catch (error) {
-        clearLoginInfo();
-        return;
-      }
-    }
+    //     error.config.headers['Authorization'] = `Bearer ${accessToken}`;
+    //     return privateApi.request(error.config);
+    //   } catch (error) {
+    //     clearLoginInfo();
+    //     return;
+    //   }
+    // }
     // 에러처리
     return Promise.reject(error);
   }

--- a/fe/src/service/constants/queryKey.ts
+++ b/fe/src/service/constants/queryKey.ts
@@ -11,4 +11,5 @@ export const QUERY_KEY = {
   followings: 'followings',
   followers: 'followers',
   collections: 'collections',
+  refresh: 'refresh',
 };

--- a/fe/src/service/queries/auth.ts
+++ b/fe/src/service/queries/auth.ts
@@ -90,6 +90,7 @@ export const useRegister = () => {
     },
   });
 };
+
 export const useRefreshToken = () => {
   const [isTokenExpiring, setIsTokenExpiring] = useState(false);
   const refreshToken = useRecoilValue(refreshTokenState);
@@ -101,6 +102,7 @@ export const useRefreshToken = () => {
 
   useEffect(() => {
     const checkInterval = setInterval(() => {
+      if (!userInfo) return;
       const isExpiring = checkTokenExpiry(JSON.parse(userInfo));
       setIsTokenExpiring(isExpiring);
     }, 30 * 1000); // 예: 30초마다 체크
@@ -125,14 +127,12 @@ export const useRefreshToken = () => {
 
       setAccessToken(accessToken);
       setRefreshToken(refreshToken);
-      // setUserInfo(JSON.stringify(payload));
       setUserInfo(JSON.stringify(payload));
     }
   }, [tokenQuery.data]);
 };
 
-export const checkTokenExpiry = (userInfo: any) => {
-  // const userInfo = getUserInfo();
+export const checkTokenExpiry = (userInfo: UserInfoType) => {
   if (!userInfo) return false;
 
   const { exp } = userInfo || { exp: 0 };
@@ -140,4 +140,6 @@ export const checkTokenExpiry = (userInfo: any) => {
   const now = Date.now() / 1000;
 
   return exp - now < 60 && exp - now > 0;
+  // 만료 1분 전인지 체크
+  // TODO 만료 시간 연장되면 더 늘리기
 };

--- a/fe/src/service/queries/auth.ts
+++ b/fe/src/service/queries/auth.ts
@@ -1,7 +1,7 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { jwtDecode } from 'jwt-decode';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import {
@@ -16,7 +16,6 @@ import {
   fetchRefresh,
   fetchRegister,
 } from 'service/axios/auth/login';
-import { QUERY_KEY } from 'service/constants/queryKey';
 import { usePageNavigator } from 'hooks/usePageNavigator';
 import { clearLoginInfo } from 'utils/localStorage';
 import { PATH } from 'constants/path';
@@ -98,7 +97,6 @@ export const useRefreshToken = () => {
   const setAccessToken = useSetRecoilState(accessTokenState);
   const setRefreshToken = useSetRecoilState(refreshTokenState);
   const setUserInfo = useSetRecoilState(userInfoState);
-  console.log('userInfo', userInfo);
 
   const refreshTokenMutation = useMutation(
     () => {
@@ -122,7 +120,8 @@ export const useRefreshToken = () => {
     }
   );
 
-  const INTERVAL_TIME = 5 * 1000;
+  const INTERVAL_TIME = 30 * 1000;
+  // TODO 30초마다 체크, 만료 시간 연장되면 더 늘리기
   useEffect(() => {
     const checkInterval = setInterval(() => {
       if (!userInfo) return;
@@ -134,73 +133,15 @@ export const useRefreshToken = () => {
 
     return () => clearInterval(checkInterval);
   }, [userInfo, refreshTokenMutation]);
-
-  // 다른 필요한 로직 추가
 };
 
-// export const useRefreshToken = () => {
-//   const [isTokenExpiring, setIsTokenExpiring] = useState(false);
-//   const refreshToken = useRecoilValue(refreshTokenState);
-//   const userInfo = useRecoilValue(userInfoState);
-//   console.log('userInfo', userInfo);
-//   // console.log('userInfo', JSON.parse(userInfo));
-
-//   const setAccessToken = useSetRecoilState(accessTokenState);
-//   const setRefreshToken = useSetRecoilState(refreshTokenState);
-//   const setUserInfo = useSetRecoilState(userInfoState);
-
-//   // const INTERVAL_TIME = 30 * 1000;
-//   const INTERVAL_TIME = 5 * 1000;
-//   // 30초마다 토큰 만료 여부 체크
-//   // TODO 만료 시간 연장되면 더 늘리기
-//   useEffect(() => {
-//     const checkInterval = setInterval(() => {
-//       if (!userInfo) return;
-//       const isExpiring = checkTokenExpiry(userInfo);
-//       // const isExpiring = checkTokenExpiry(JSON.parse(userInfo));
-//       setIsTokenExpiring(isExpiring);
-//     }, INTERVAL_TIME);
-
-//     return () => clearInterval(checkInterval);
-//   }, [userInfo]);
-
-//   const tokenQuery = useQuery({
-//     queryKey: [QUERY_KEY.refresh],
-//     queryFn: () => {
-//       if (!refreshToken) return Promise.reject();
-//       return fetchRefresh(refreshToken);
-//     },
-//     enabled: isTokenExpiring, // 토큰 만료 여부에 따라 쿼리 활성화
-//     refetchOnWindowFocus: true,
-//     refetchOnMount: true,
-//   });
-
-//   useEffect(() => {
-//     if (tokenQuery.data) {
-//       const { accessToken, refreshToken } = tokenQuery.data;
-//       const payload = jwtDecode(accessToken);
-//       const ref = jwtDecode(refreshToken);
-//       console.log('payload ref', ref);
-
-//       setAccessToken(accessToken);
-//       setRefreshToken(refreshToken);
-//       setUserInfo(JSON.stringify(payload));
-//     }
-//   }, [tokenQuery.data]);
-// };
-
-export const checkTokenExpiry = (userInfo: any) => {
+export const checkTokenExpiry = (userInfo: UserInfoType) => {
   const { exp } = userInfo;
-  console.log('exp', exp);
-
   const now = Date.now() / 1000;
   const BEFORE_EXPIRY = 60;
   // exp: 만료 시간
   // 만료 1분 전인지 체크
   // TODO 만료 시간 연장되면 더 늘리기
-  console.log('expire ??', exp - now < BEFORE_EXPIRY);
-  console.log('valid ??', exp - now > 0);
 
-  // return exp - now < BEFORE_EXPIRY && exp - now > 0;
   return exp - now < BEFORE_EXPIRY;
 };

--- a/fe/src/types/auth.d.ts
+++ b/fe/src/types/auth.d.ts
@@ -10,3 +10,10 @@ type RegisterBody = {
   reconfirmPassword: string;
   tasteMoodId?: string;
 };
+type UserInfoType = {
+  email: string;
+  exp: number;
+  iat: number;
+  id: string;
+  iss: string;
+};

--- a/fe/src/types/auth.d.ts
+++ b/fe/src/types/auth.d.ts
@@ -10,6 +10,7 @@ type RegisterBody = {
   reconfirmPassword: string;
   tasteMoodId?: string;
 };
+
 type UserInfoType = {
   email: string;
   exp: number;


### PR DESCRIPTION
## Key changes🔧
- 토큰만료되면 바로 재발급 / 오류 안받음
## To reviewer👋
- 기존 sse의 onError를 통해 401에러 캐치후 -> 토큰 재발급 요청을 보내는 로직에서 useRefreshToken을 이용하여 accessToken의 만료 시간을 체크하고 만료가 임박할때 re-issue를 요청하여 401에러 응답을 받지 않게 개선함
- 불필요한 에러 로깅을 막고 fetcher와 notiIcon에서의 중복 코드를 제거 
