### PR TITLE
[FE] headerMob에 있는 알림아이콘에 notipage navigate추가 (#413)

### DIFF
--- a/fe/src/components/common/headerMob/HeaderMob.tsx
+++ b/fe/src/components/common/headerMob/HeaderMob.tsx
@@ -8,9 +8,10 @@ import { GearIcon, LogoLarge } from '../icon/icons';
 import { PATH } from 'constants/path';
 
 export const HeaderMob: React.FC = () => {
-  const { navigateToHome, navigateToProfileSetting } = usePageNavigator();
+  const { navigateToHome, navigateToProfileSetting, navigateToNoti } =
+    usePageNavigator();
   const currentLocation = useLocation();
-  const allowedPaths = [PATH.PROFILE, PATH.PASSWORD, PATH.HOME];
+  const allowedPaths = [PATH.PROFILE, PATH.PASSWORD, PATH.HOME, PATH.NOTI];
   const accessToSetting = allowedPaths.includes(currentLocation.pathname);
 
   return (
@@ -18,7 +19,7 @@ export const HeaderMob: React.FC = () => {
       <FlexRowBox>
         <LogoLarge onClick={navigateToHome} />
         <ContentRight>
-          <NotiIcon />
+          <NotiIcon onClick={navigateToNoti} />
           {accessToSetting && <GearIcon onClick={navigateToProfileSetting} />}
         </ContentRight>
       </FlexRowBox>


### PR DESCRIPTION
* feat: 컬렉션 메인 조회 api연동

* chore: 필요없는 코드 제거

* chore: css 보더 제거

* feat: 컴포넌트 분리 및 listItem에 드롭다운 추가

* chore: 빌드오류 수정

* chore: 타임스탬프 파일 삭제

* feat: 로그인 오류 수정

* feat: 이미지 업로드 컴포넌트에 로딩 spinner 추가

* fix: headerMob에서 noti페이지 navigate 추가

## Key changes🔧
- 
## To reviewer👋
- 
