### PR TITLE
[FE] 컬렉션 메인 조회 select정렬 연동

### DIFF
--- a/fe/src/components/collection/CollectionContainer.tsx
+++ b/fe/src/components/collection/CollectionContainer.tsx
@@ -1,4 +1,5 @@
 import { useToggle } from 'recoil/booleanState/useToggle';
+import { useSort } from 'recoil/sortState/useSort';
 import { useGetCollection } from 'service/queries/collection';
 import { styled } from 'styled-components';
 import { GridLayout } from './GridLayout';
@@ -6,7 +7,8 @@ import { ListLayout } from './ListLayout';
 
 export const CollectionContainer = () => {
   // TODO 프로필에 쓰이는거는 위로 올려야함
-  const { collections, hasNextPage, fetchNextPage } = useGetCollection();
+  const { sortBy } = useSort('collection');
+  const { collections, hasNextPage, fetchNextPage } = useGetCollection(sortBy);
   console.log(collections);
   const grid = useToggle('grid');
 

--- a/fe/src/components/layoutButton/LayoutButton.tsx
+++ b/fe/src/components/layoutButton/LayoutButton.tsx
@@ -10,7 +10,6 @@ import {
 
 export const LayoutButton = () => {
   const grid = useToggle('grid');
-  // const { isGrid, handleSetOn, handleSetOff } = useSetLayout();
 
   return (
     <Wrapper>

--- a/fe/src/components/sort/SelectSort.tsx
+++ b/fe/src/components/sort/SelectSort.tsx
@@ -1,0 +1,55 @@
+import { useSort } from 'recoil/sortState/useSort';
+import { styled } from 'styled-components';
+import { ArrowDownIcon } from 'components/common/icon/icons';
+
+export const SelectSort = () => {
+  const { handleSort } = useSort('collection');
+
+  const OPTIONS = [
+    { id: '1', name: '최신순', value: 'createdAt' },
+    { id: '2', name: '좋아요순', value: 'heartCount' },
+  ];
+
+  return (
+    <SelectLabel>
+      <Select onChange={handleSort}>
+        {OPTIONS.map((option: { id: string; name: string; value: string }) => (
+          <Option key={option.id} value={option.value}>
+            {option.name}
+          </Option>
+        ))}
+      </Select>
+      <ArrowDownIcon />
+    </SelectLabel>
+  );
+};
+const SelectLabel = styled.label`
+  position: relative;
+  width: 90px;
+  svg {
+    position: absolute;
+    right: 4px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+`;
+
+const Select = styled.select`
+  -webkit-appearance: none;
+  padding: 8px;
+  width: 90px;
+  background: white;
+  border: 1px solid ${({ theme: { colors } }) => colors.black};
+
+  border-radius: 4px;
+  background: ${({ theme: { colors } }) => colors.white};
+  cursor: pointer;
+  font: ${({ theme: { fonts } }) => fonts.displayM12};
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme: { colors } }) => colors.textTertiary};
+  }
+`;
+
+const Option = styled.option``;

--- a/fe/src/pages/CollectionPage.tsx
+++ b/fe/src/pages/CollectionPage.tsx
@@ -2,8 +2,8 @@ import { styled } from 'styled-components';
 import { media } from 'styles/mediaQuery';
 import { CollectionContainer } from 'components/collection/CollectionContainer';
 import { CollectionCarousel } from 'components/common/carousel/CollectionCarousel';
-// import { GridItem } from 'components/collection/GridItem';
 import { LayoutButton } from 'components/layoutButton/LayoutButton';
+import { SelectSort } from 'components/sort/SelectSort';
 
 export const CollectionPage = () => {
   return (
@@ -21,10 +21,10 @@ export const CollectionPage = () => {
             </HeaderLeft>
             <HeaderRight>
               <Text>푸디무디들이 엄선한 맛집모음!</Text>
-              <SortBox>
-                <Dummy>{/* 셀렉트component자리*/}</Dummy>
+              <SortContainer>
+                <SelectSort />
                 <LayoutButton />
-              </SortBox>
+              </SortContainer>
             </HeaderRight>
           </Header>
           <CollectionContainer />
@@ -50,8 +50,6 @@ const ContentWrapper = styled.div`
   gap: 56px;
   width: 566px;
   height: 100%;
-  /* border-left: 1px solid ${({ theme: { colors } }) => colors.black};
-  border-right: 1px solid ${({ theme: { colors } }) => colors.black}; */
 
   ${media.md} {
     max-width: 568px;
@@ -63,16 +61,6 @@ const ContentWrapper = styled.div`
     border-right: none;
   }
 `;
-
-/* 컬렉션 */
-
-// const generateDefaultImage = (imageUrl: string) =>
-//   `https://source.boringavatars.com/beam/${imageUrl}?colors=FF4E50,FC913A,F9D423,EDE574,E1F5C4&square`;
-
-// const MOCK_FEEDS = Array.from({ length: 3 }, (_, index) => ({
-//   id: index + 1,
-//   imageUrl: generateDefaultImage(`githubrandomProfileimageurl${index + 1}`),
-// }));
 
 const HeaderContent = styled.div`
   width: 100%;
@@ -98,9 +86,6 @@ const BodyContent = styled.div`
 const Header = styled.div`
   display: flex;
   flex-direction: column;
-  /* gap: 4px; */
-  /* justify-content: space-between;
-  align-items: center; */
 `;
 
 const HeaderLeft = styled.div`
@@ -112,7 +97,6 @@ const HeaderRight = styled.div`
   display: flex;
   align-items: center;
   gap: 16px;
-  /* justify-content: flex-end; */
   justify-content: space-between;
 `;
 
@@ -120,18 +104,10 @@ const Text = styled.div`
   font: ${({ theme: { fonts } }) => fonts.displayM16};
 `;
 
-const SortBox = styled.div`
+const SortContainer = styled.div`
   display: flex;
   align-items: center;
   gap: 16px;
-`;
-
-const Dummy = styled.div`
-  width: 120px;
-  height: 30px;
-  background: white;
-  border: 1px solid black;
-  border-radius: 4px;
 `;
 
 // const BannerContent = styled.div`

--- a/fe/src/recoil/sortState/atom.ts
+++ b/fe/src/recoil/sortState/atom.ts
@@ -1,0 +1,7 @@
+import { atomFamily } from 'recoil';
+
+// 다른 쪽에서도 sort를 쓸 가능성
+export const sortStateFamily = atomFamily({
+  key: 'sortStateFamily',
+  default: 'createdAt',
+});

--- a/fe/src/recoil/sortState/useSort.ts
+++ b/fe/src/recoil/sortState/useSort.ts
@@ -1,0 +1,13 @@
+import { useRecoilState } from 'recoil';
+import { sortStateFamily } from './atom';
+
+export const useSort = (id: string) => {
+  // TODO sort 사용처 Type정의
+  const [sortBy, setSortBy] = useRecoilState(sortStateFamily(id));
+
+  const handleSort: React.ChangeEventHandler<HTMLSelectElement> = (e) => {
+    setSortBy(e.target.value);
+  };
+
+  return { sortBy, handleSort };
+};

--- a/fe/src/service/axios/collection/collection.ts
+++ b/fe/src/service/axios/collection/collection.ts
@@ -1,8 +1,12 @@
 import { publicApi } from 'service/axios/fetcher';
 import { END_POINT } from 'service/constants/endpoint';
 
-export const getAllCollections = async (page = 0, size = 10) => {
-  const { data } = await publicApi.get(END_POINT.collection(), {
+export const getAllCollections = async (
+  page = 0,
+  size = 10,
+  sort: string = 'createdAt'
+) => {
+  const { data } = await publicApi.get(END_POINT.collection(undefined, sort), {
     params: { page, size },
   });
   return data;

--- a/fe/src/service/constants/endpoint.ts
+++ b/fe/src/service/constants/endpoint.ts
@@ -1,11 +1,13 @@
 export const END_POINT = {
   login: `/auth/login`,
   logout: `/auth/logout`,
-  refresh: `/auth/token`, // 수정가능성
+  refresh: `/auth/token`,
   tasteMood: `/members/taste-moods`,
   storeMood: `/feeds/store-moods`,
-  collection: (id?: string) =>
-    id ? `/feed_collections/${id}` : `/feed_collections`,
+  collection: (
+    id?: string,
+    sort?: string // TODO sort 타입 정의
+  ) => (id ? `/feed_collections/${id}` : `/feed_collections?sort=${sort}`),
   feedLike: (id: string) => `/feeds/${id}/likes`,
   commentLike: (id: string) => `/comments/${id}/likes`,
   replyLike: ({ commentId, replyId }: ReplyLike) =>

--- a/fe/src/service/queries/collection.ts
+++ b/fe/src/service/queries/collection.ts
@@ -3,11 +3,12 @@ import { useMemo } from 'react';
 import { getAllCollections } from 'service/axios/collection/collection';
 import { QUERY_KEY } from 'service/constants/queryKey';
 
-export const useGetCollection = () => {
+export const useGetCollection = (sortBy?: string) => {
+  //  TODO sortBy 타입 정의
   const { data, hasNextPage, status, isLoading, fetchNextPage } =
     useInfiniteQuery({
-      queryKey: [QUERY_KEY.collections],
-      queryFn: ({ pageParam = 0 }) => getAllCollections(pageParam),
+      queryKey: [QUERY_KEY.collections, sortBy],
+      queryFn: ({ pageParam = 0 }) => getAllCollections(pageParam, 10, sortBy),
       getNextPageParam: (lastPage) => {
         return lastPage.last ? undefined : lastPage.number + 1;
       },


### PR DESCRIPTION
## Key changes🔧
- collection page의 select box 분리
- 정렬
  - createdAt (기본정렬값/ 최신순) 
  - heartCount (좋아요순)
    - 각각의 네이밍은 추후 수정해주신다고 합니다
## To reviewer👋
- 프로필페이지의 컬렉션 조회에서도 sort를 놔도 괜찮아보일 것 같아서 혹시 또 쓸까봐 atomFamily로 해봤습니다
  - 아직 추가는 안함 just가능성
