### PR TITLE
[FE] 임시 이미지 최적화 

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^18.2.0",
         "react-helmet-async": "^2.0.4",
         "react-hook-form": "^7.49.2",
+        "react-image-file-resizer": "^0.4.8",
         "react-loading-skeleton": "^3.3.1",
         "react-router-dom": "^6.16.0",
         "react-slick": "^0.29.0",
@@ -3911,6 +3912,11 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
       }
+    },
+    "node_modules/react-image-file-resizer": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/react-image-file-resizer/-/react-image-file-resizer-0.4.8.tgz",
+      "integrity": "sha512-Ue7CfKnSlsfJ//SKzxNMz8avDgDSpWQDOnTKOp/GNRFJv4dO9L5YGHNEnj40peWkXXAK2OK0eRIoXhOYpUzUTQ=="
     },
     "node_modules/react-is": {
       "version": "16.13.1",

--- a/fe/package.json
+++ b/fe/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^18.2.0",
     "react-helmet-async": "^2.0.4",
     "react-hook-form": "^7.49.2",
+    "react-image-file-resizer": "^0.4.8",
     "react-loading-skeleton": "^3.3.1",
     "react-router-dom": "^6.16.0",
     "react-slick": "^0.29.0",

--- a/fe/src/components/common/menuItemEditor/ImageBox.tsx
+++ b/fe/src/components/common/menuItemEditor/ImageBox.tsx
@@ -3,6 +3,7 @@ import { useToast } from 'recoil/toast/useToast';
 import { usePostImage } from 'service/queries/imageUpload';
 import { styled } from 'styled-components';
 import { generateDefaultUserImage } from 'utils/generateDefaultUserImage';
+import { resizeImage } from 'utils/resizeImage';
 import { PlusGhostIcon } from '../icon/icons';
 import { Spinner } from '../loading/spinner';
 
@@ -35,7 +36,7 @@ export const ImageBox: React.FC<Props> = ({
     }
   };
 
-  const handleUploadImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleUploadImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
 
     if (!file) {
@@ -43,17 +44,25 @@ export const ImageBox: React.FC<Props> = ({
     }
 
     const ALLOWED_TYPES = ['image/png', 'image/jpg', 'image/jpeg'];
-    const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 2; // 2MB
+    const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 2.6; // 2MB
 
     if (!ALLOWED_TYPES.includes(file.type) || file.size > MAX_FILE_SIZE_BYTES) {
       toast.noti(
-        '이미지는 2MB 이하의 png, jpg, jpeg 파일만 업로드 가능합니다.'
+        '이미지는 2.6MB 이하의 png, jpg, jpeg 파일만 업로드 가능합니다.'
       );
       return;
     }
 
+    const resizedFile = (await resizeImage({
+      file,
+      maxWidth: 850,
+      maxHeight: 850,
+    })) as File;
+    console.log('resizedFile', resizedFile);
+
     const formData = new FormData();
-    formData.append('file', file);
+    formData.append('file', resizedFile);
+    // formData.append('file', file);
 
     imageMutate(formData, {
       onSuccess: (res) => {

--- a/fe/src/components/common/userImage/UserImageEdit.tsx
+++ b/fe/src/components/common/userImage/UserImageEdit.tsx
@@ -6,6 +6,7 @@ import { styled } from 'styled-components';
 import { media } from 'styles/mediaQuery';
 import { useAuthState } from 'hooks/auth/useAuth';
 import { generateDefaultUserImage } from 'utils/generateDefaultUserImage';
+import { resizeImage } from 'utils/resizeImage';
 import { EditIcon } from '../icon/icons';
 import { useModal } from '../modal/useModal';
 import { UserImage } from './UserImage';
@@ -46,25 +47,40 @@ export const UserImageEdit: React.FC<Props> = ({
     }
   };
 
-  const handleUploadImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleUploadImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
+    console.log('file', file);
+    console.log('file', typeof file);
 
     if (!file) {
       return;
     }
 
-    const ALLOWED_TYPES = ['image/png', 'image/jpg', 'image/jpeg'];
-    const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 2; // 2MB
+    const ALLOWED_TYPES = [
+      'image/png',
+      'image/jpg',
+      'image/jpeg',
+      'image/webp',
+    ];
+    const MAX_FILE_SIZE_BYTES = 1024 * 1024 * 2.6; // 2MB
 
     if (!ALLOWED_TYPES.includes(file.type) || file.size > MAX_FILE_SIZE_BYTES) {
       toast.noti(
-        '이미지는 2MB 이하의 png, jpg, jpeg 파일만 업로드 가능합니다.'
+        '이미지는 2.6MB 이하의 png, jpg, jpeg 파일만 업로드 가능합니다.'
       );
       return;
     }
 
+    const resizedFile = (await resizeImage({
+      file,
+      maxWidth: 200,
+      maxHeight: 200,
+    })) as File;
+    console.log('resizedFile', resizedFile);
+
     const formData = new FormData();
-    formData.append('file', file);
+    formData.append('file', resizedFile);
+    // formData.append('file', file);
 
     imageMutate(formData, {
       onSuccess: (res) => {

--- a/fe/src/utils/resizeImage.ts
+++ b/fe/src/utils/resizeImage.ts
@@ -1,0 +1,27 @@
+import Resizer from 'react-image-file-resizer';
+
+type Props = {
+  file: Blob;
+  maxWidth: number;
+  maxHeight: number;
+};
+
+export const resizeImage = ({ file, maxWidth, maxHeight }: Props) => {
+  const format = file.name.slice(file.name.lastIndexOf('.') + 1).toLowerCase();
+  const compressFormat = format === 'png' ? 'png' : 'jpeg';
+
+  return new Promise((res) => {
+    Resizer.imageFileResizer(
+      file,
+      maxWidth,
+      maxHeight,
+      compressFormat,
+      100,
+      0,
+      (uri) => {
+        res(uri);
+      },
+      'file'
+    );
+  });
+};


### PR DESCRIPTION
## Key changes🔧
- s3 iam받기 전까지 적용
- 라이브러리 제공 함수를 한번 거쳐서 서버에 업로드 하는 방식
- [React Image File Resizer 라이브러리 사용](https://www.npmjs.com/package/react-image-file-resizer)
  - browser-image-compression은 사진이 종종 뒤집어지는 버그가 있다고함
- [webp로 바꾸고싶었으나 서버 업로드시 jpg, png만 지원중](https://foodymoody.site/api/docs#_%EC%A7%80%EC%9B%90%EB%90%98%EC%A7%80_%EC%95%8A%EB%8A%94_%ED%98%95%EC%8B%9D%EC%9D%98_%EC%9D%B4%EB%AF%B8%EC%A7%80%EC%9D%BC_%EB%95%8C)
## To reviewer👋
- 화질저하가 심하여 돔 사이즈보다 1.5배정도 크게 설정
- 페치 속도
  - 위가 리사이즈 후, 아래가 3000px짜리 원본
![image](https://github.com/foody-moody/foodymoody/assets/86706366/e39daa63-ebc3-4eec-b702-87b2c4833b35)

- 피드이미지 리사이징 적용 전
![image](https://github.com/foody-moody/foodymoody/assets/86706366/60a56372-8885-4a79-802c-eec1279c752d)
- 피드이미지 리사이징 적용 후
![image](https://github.com/foody-moody/foodymoody/assets/86706366/c2ca45b9-571b-499e-9db0-5d097535a799)
- 프로필이미지 리사이징 적용 전
![image](https://github.com/foody-moody/foodymoody/assets/86706366/f84489aa-1374-49e1-9b8b-034fb4ffa441)
- 프로필이미지 리사이징 적용 후
![image](https://github.com/foody-moody/foodymoody/assets/86706366/86d97484-933c-4ac6-9d66-2097d2b704f8)

